### PR TITLE
fix(nft-base-api): renamed senderPublicKey to ownerPublicKey in assets and collections resources

### DIFF
--- a/packages/nft-base-api/__tests__/integration/handlers/assets.test.ts
+++ b/packages/nft-base-api/__tests__/integration/handlers/assets.test.ts
@@ -6,9 +6,9 @@ import { ApiHelpers } from "@arkecosystem/core-test-framework/src";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
 import { Identities } from "@arkecosystem/crypto";
 import { NFTBaseTransactionFactory } from "@protokol/nft-base-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory";
+import { INFTTokens } from "@protokol/nft-base-transactions/src/interfaces";
 
 import { setUp, tearDown } from "../__support__/setup";
-import { INFTTokens } from "@protokol/nft-base-transactions/src/interfaces";
 
 let app: Contracts.Kernel.Application;
 let api: ApiHelpers;
@@ -50,7 +50,7 @@ describe("API - Assets", () => {
 
             const response = await api.request("GET", "nft/assets");
             expect(response.data.data[0].id).toStrictEqual(nftCreate.id);
-            expect(response.data.data[0].senderPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
+            expect(response.data.data[0].ownerPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
             expect(response.data.data[0].collectionId).toStrictEqual(
                 "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             );
@@ -64,16 +64,17 @@ describe("API - Assets", () => {
                 Container.Identifiers.DatabaseTransactionRepository,
             );
 
-            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([{
-                ...nftCreate.data,
-                serialized: nftCreate.serialized,
-            }]);
-
+            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([
+                {
+                    ...nftCreate.data,
+                    serialized: nftCreate.serialized,
+                },
+            ]);
 
             const response = await api.request("GET", `nft/assets/${nftCreate.id}`);
 
             expect(response.data.data.id).toStrictEqual(nftCreate.id);
-            expect(response.data.data.senderPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
+            expect(response.data.data.ownerPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
             expect(response.data.data.collectionId).toStrictEqual(
                 "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             );
@@ -124,7 +125,7 @@ describe("API - Assets", () => {
                 damage: 3,
             });
             expect(response.data.data[0].id).toStrictEqual(nftCreate.id);
-            expect(response.data.data[0].senderPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
+            expect(response.data.data[0].ownerPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
             expect(response.data.data[0].collectionId).toStrictEqual(
                 "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             );

--- a/packages/nft-base-api/__tests__/integration/handlers/collections.test.ts
+++ b/packages/nft-base-api/__tests__/integration/handlers/collections.test.ts
@@ -6,9 +6,9 @@ import { ApiHelpers } from "@arkecosystem/core-test-framework/src";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
 import { Identities } from "@arkecosystem/crypto";
 import { NFTBaseTransactionFactory } from "@protokol/nft-base-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory";
+import { INFTCollections } from "@protokol/nft-base-transactions/src/interfaces";
 
 import { setUp, tearDown } from "../__support__/setup";
-import { INFTCollections } from "@protokol/nft-base-transactions/src/interfaces";
 
 let app: Contracts.Kernel.Application;
 let api: ApiHelpers;
@@ -66,7 +66,7 @@ describe("API - Collections", () => {
             api.expectPaginator(response);
             expect(response.data.data).toBeArray();
             expect(response.data.data[0].id).toStrictEqual(nftRegisteredCollection.id);
-            expect(response.data.data[0].senderPublicKey).toStrictEqual(nftRegisteredCollection.data.senderPublicKey);
+            expect(response.data.data[0].ownerPublicKey).toStrictEqual(nftRegisteredCollection.data.senderPublicKey);
             expect(response.data.data[0].name).toStrictEqual("Nft card");
             expect(response.data.data[0].description).toStrictEqual("Nft card description");
             expect(response.data.data[0].maximumSupply).toStrictEqual(100);
@@ -80,16 +80,18 @@ describe("API - Collections", () => {
                 Container.Identifiers.DatabaseTransactionRepository,
             );
 
-            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([{
-                ...nftRegisteredCollection.data,
-                serialized: nftRegisteredCollection.serialized,
-            }]);
+            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([
+                {
+                    ...nftRegisteredCollection.data,
+                    serialized: nftRegisteredCollection.serialized,
+                },
+            ]);
 
             const response = await api.request("GET", `nft/collections/${nftRegisteredCollection.id}`);
 
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data.id).toBe(nftRegisteredCollection.id);
-            expect(response.data.data.senderPublicKey).toStrictEqual(nftRegisteredCollection.data.senderPublicKey);
+            expect(response.data.data.ownerPublicKey).toStrictEqual(nftRegisteredCollection.data.senderPublicKey);
             expect(response.data.data.name).toStrictEqual("Nft card");
             expect(response.data.data.description).toStrictEqual("Nft card description");
             expect(response.data.data.maximumSupply).toStrictEqual(100);
@@ -103,10 +105,12 @@ describe("API - Collections", () => {
                 Container.Identifiers.DatabaseTransactionRepository,
             );
 
-            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([{
-                ...nftRegisteredCollection.data,
-                serialized: nftRegisteredCollection.serialized,
-            }]);
+            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([
+                {
+                    ...nftRegisteredCollection.data,
+                    serialized: nftRegisteredCollection.serialized,
+                },
+            ]);
 
             const response = await api.request("GET", `nft/collections/${nftRegisteredCollection.id}/schema`);
 
@@ -188,7 +192,7 @@ describe("API - Collections", () => {
             api.expectPaginator(response);
             expect(response.data.data).toBeArray();
             expect(response.data.data[0].id).toStrictEqual(nftRegisteredCollection.id);
-            expect(response.data.data[0].senderPublicKey).toStrictEqual(nftRegisteredCollection.data.senderPublicKey);
+            expect(response.data.data[0].ownerPublicKey).toStrictEqual(nftRegisteredCollection.data.senderPublicKey);
             expect(response.data.data[0].name).toStrictEqual("Nft card");
             expect(response.data.data[0].description).toStrictEqual("Nft card description");
             expect(response.data.data[0].maximumSupply).toStrictEqual(100);
@@ -223,7 +227,7 @@ describe("API - Collections", () => {
             const response = await api.request("GET", `nft/collections/${nftToken.id}/assets`);
             expect(response).toBeSuccessfulResponse();
             expect(response.data.data[0].id).toStrictEqual(nftToken.id);
-            expect(response.data.data[0].senderPublicKey).toStrictEqual(nftToken.data.senderPublicKey);
+            expect(response.data.data[0].ownerPublicKey).toStrictEqual(nftToken.data.senderPublicKey);
             expect(response.data.data[0].collectionId).toStrictEqual(
                 "5fe521beb05636fbe16d2eb628d835e6eb635070de98c3980c9ea9ea4496061a",
             );

--- a/packages/nft-base-api/__tests__/unit/controllers/assets.test.ts
+++ b/packages/nft-base-api/__tests__/unit/controllers/assets.test.ts
@@ -84,7 +84,7 @@ describe("Test asset controller", () => {
         const response = (await assetController.index(request, undefined)) as PaginatedResponse;
         expect(response.results[0]).toStrictEqual({
             id: actual.id,
-            senderPublicKey: Identities.PublicKey.fromPassphrase(passphrases[0]),
+            ownerPublicKey: Identities.PublicKey.fromPassphrase(passphrases[0]),
             collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             attributes: {
                 name: "card name",
@@ -132,7 +132,7 @@ describe("Test asset controller", () => {
 
         expect(response.data).toStrictEqual({
             id: actual.id,
-            senderPublicKey: senderWallet.publicKey,
+            ownerPublicKey: senderWallet.publicKey,
             collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             attributes: {
                 name: "card name",
@@ -158,7 +158,7 @@ describe("Test asset controller", () => {
         const response = (await assetController.showByAsset(request, undefined)) as PaginatedResponse;
         expect(response.results[0]).toStrictEqual({
             id: actual.id,
-            senderPublicKey: Identities.PublicKey.fromPassphrase(passphrases[0]),
+            ownerPublicKey: Identities.PublicKey.fromPassphrase(passphrases[0]),
             collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             attributes: {
                 name: "card name",

--- a/packages/nft-base-api/__tests__/unit/controllers/collections.test.ts
+++ b/packages/nft-base-api/__tests__/unit/controllers/collections.test.ts
@@ -113,7 +113,7 @@ describe("Test collection controller", () => {
 
         expect(response.results[0]).toStrictEqual({
             id: actual.id,
-            senderPublicKey: actual.data.senderPublicKey,
+            ownerPublicKey: actual.data.senderPublicKey,
             name: "Heartstone card",
             description: "A card from heartstone game",
             maximumSupply: 100,
@@ -172,7 +172,7 @@ describe("Test collection controller", () => {
         const response = (await collectionController.show(request, undefined)) as ItemResponse;
         expect(response.data).toStrictEqual({
             id: actual.id,
-            senderPublicKey: actual.data.senderPublicKey,
+            ownerPublicKey: actual.data.senderPublicKey,
             name: "Heartstone card",
             description: "A card from heartstone game",
             maximumSupply: 100,
@@ -224,7 +224,7 @@ describe("Test collection controller", () => {
         const response = (await collectionController.searchCollection(request, undefined)) as PaginatedResponse;
         expect(response.results[0]).toStrictEqual({
             id: actual.id,
-            senderPublicKey: actual.data.senderPublicKey,
+            ownerPublicKey: actual.data.senderPublicKey,
             name: "Heartstone card",
             description: "A card from heartstone game",
             maximumSupply: 100,
@@ -265,7 +265,7 @@ describe("Test collection controller", () => {
         const response = (await collectionController.showAssetsByCollectionId(request, undefined)) as PaginatedResponse;
         expect(response.results[0]).toStrictEqual({
             id: actual.id,
-            senderPublicKey: actual.data.senderPublicKey,
+            ownerPublicKey: actual.data.senderPublicKey,
             collectionId: "5fe521beb05636fbe16d2eb628d835e6eb635070de98c3980c9ea9ea4496061a",
             attributes: {
                 number: 5,

--- a/packages/nft-base-api/src/resources/assets.ts
+++ b/packages/nft-base-api/src/resources/assets.ts
@@ -24,7 +24,7 @@ export class AssetResource implements Contracts.Resource {
     public transform(resource): object {
         return {
             id: resource.id,
-            senderPublicKey: resource.senderPublicKey,
+            ownerPublicKey: resource.senderPublicKey,
             ...resource.asset.nftToken,
         };
     }

--- a/packages/nft-base-api/src/resources/collections.ts
+++ b/packages/nft-base-api/src/resources/collections.ts
@@ -24,7 +24,7 @@ export class CollectionResource implements Contracts.Resource {
     public transform(resource): object {
         return {
             id: resource.id,
-            senderPublicKey: resource.senderPublicKey,
+            ownerPublicKey: resource.senderPublicKey,
             ...resource.asset.nftCollection,
         };
     }


### PR DESCRIPTION
… and collections resources

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Renamed senderPublicKey to ownerPublicKey in assets and collections resources.
Issue #4 and #3 

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->

