### PR TITLE
fix(nft-base-api): renamed senderPublicKey to ownerPublicKey

### DIFF
--- a/packages/nft-base-api/__tests__/integration/handlers/assets.test.ts
+++ b/packages/nft-base-api/__tests__/integration/handlers/assets.test.ts
@@ -6,9 +6,9 @@ import { ApiHelpers } from "@arkecosystem/core-test-framework/src";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
 import { Identities } from "@arkecosystem/crypto";
 import { NFTBaseTransactionFactory } from "@protokol/nft-base-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory";
+import { INFTTokens } from "@protokol/nft-base-transactions/src/interfaces";
 
 import { setUp, tearDown } from "../__support__/setup";
-import { INFTTokens } from "@protokol/nft-base-transactions/src/interfaces";
 
 let app: Contracts.Kernel.Application;
 let api: ApiHelpers;
@@ -19,6 +19,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => await tearDown());
+
+let walletRepository: Contracts.State.WalletRepository;
 
 describe("API - Assets", () => {
     let nftCreate;
@@ -35,6 +37,20 @@ describe("API - Assets", () => {
             })
             .withPassphrase(secrets[0])
             .build()[0];
+
+        walletRepository = app.getTagged<Contracts.State.WalletRepository>(
+            Container.Identifiers.WalletRepository,
+            "state",
+            "blockchain",
+        );
+        const wallet = walletRepository.findByAddress(Identities.Address.fromPassphrase(secrets[0]));
+
+        const tokensWallet = wallet.getAttribute<INFTTokens>("nft.base.tokenIds", []);
+        // @ts-ignore
+        tokensWallet[nftCreate.data.id] = {};
+        wallet.setAttribute<INFTTokens>("nft.base.tokenIds", tokensWallet);
+
+        walletRepository.index(wallet);
     });
     describe("GET /assets", () => {
         it("should return all nft create transactions", async () => {
@@ -50,7 +66,7 @@ describe("API - Assets", () => {
 
             const response = await api.request("GET", "nft/assets");
             expect(response.data.data[0].id).toStrictEqual(nftCreate.id);
-            expect(response.data.data[0].senderPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
+            expect(response.data.data[0].ownerPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
             expect(response.data.data[0].collectionId).toStrictEqual(
                 "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             );
@@ -64,16 +80,17 @@ describe("API - Assets", () => {
                 Container.Identifiers.DatabaseTransactionRepository,
             );
 
-            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([{
-                ...nftCreate.data,
-                serialized: nftCreate.serialized,
-            }]);
-
+            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([
+                {
+                    ...nftCreate.data,
+                    serialized: nftCreate.serialized,
+                },
+            ]);
 
             const response = await api.request("GET", `nft/assets/${nftCreate.id}`);
 
             expect(response.data.data.id).toStrictEqual(nftCreate.id);
-            expect(response.data.data.senderPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
+            expect(response.data.data.ownerPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
             expect(response.data.data.collectionId).toStrictEqual(
                 "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             );
@@ -82,19 +99,15 @@ describe("API - Assets", () => {
     });
 
     describe("GET /assets/{id}/wallets", () => {
-        let walletRepository: Contracts.State.WalletRepository;
-
         it("should return wallet by token id", async () => {
             walletRepository = app.getTagged<Contracts.State.WalletRepository>(
                 Container.Identifiers.WalletRepository,
                 "state",
                 "blockchain",
             );
-            walletRepository.reset();
             const wallet = walletRepository.findByAddress(Identities.Address.fromPassphrase(secrets[0]));
 
             const tokensWallet = wallet.getAttribute<INFTTokens>("nft.base.tokenIds", []);
-            // @ts-ignore
             tokensWallet["8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61"] = {};
             wallet.setAttribute<INFTTokens>("nft.base.tokenIds", tokensWallet);
 
@@ -123,8 +136,9 @@ describe("API - Assets", () => {
             const response = await api.request("POST", "nft/assets/search", {
                 damage: 3,
             });
+            console.log(response.data.data);
             expect(response.data.data[0].id).toStrictEqual(nftCreate.id);
-            expect(response.data.data[0].senderPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
+            expect(response.data.data[0].ownerPublicKey).toStrictEqual(nftCreate.data.senderPublicKey);
             expect(response.data.data[0].collectionId).toStrictEqual(
                 "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             );

--- a/packages/nft-base-api/__tests__/integration/handlers/burns.test.ts
+++ b/packages/nft-base-api/__tests__/integration/handlers/burns.test.ts
@@ -55,10 +55,12 @@ describe("API - Burns", () => {
                 Container.Identifiers.DatabaseTransactionRepository,
             );
 
-            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([{
-                ...nftBurn.data,
-                serialized: nftBurn.serialized,
-            }]);
+            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([
+                {
+                    ...nftBurn.data,
+                    serialized: nftBurn.serialized,
+                },
+            ]);
 
             const response = await api.request("GET", `nft/burns/${nftBurn.id}`);
             expect(response.data.data.id).toStrictEqual(nftBurn.id);

--- a/packages/nft-base-api/__tests__/integration/handlers/transfers.test.ts
+++ b/packages/nft-base-api/__tests__/integration/handlers/transfers.test.ts
@@ -60,10 +60,12 @@ describe("API - Transfers", () => {
                 Container.Identifiers.DatabaseTransactionRepository,
             );
 
-            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([{
-                ...nftTransfer.data,
-                serialized: nftTransfer.serialized,
-            }]);
+            jest.spyOn(transactionRepository, "findManyByExpression").mockResolvedValueOnce([
+                {
+                    ...nftTransfer.data,
+                    serialized: nftTransfer.serialized,
+                },
+            ]);
 
             const response = await api.request("GET", `nft/transfers/${nftTransfer.id}`);
 

--- a/packages/nft-base-api/__tests__/unit/controllers/assets.test.ts
+++ b/packages/nft-base-api/__tests__/unit/controllers/assets.test.ts
@@ -61,6 +61,12 @@ beforeEach(() => {
         })
         .sign(passphrases[0])
         .build();
+
+    const tokensWallet = senderWallet.getAttribute<INFTTokens>("nft.base.tokenIds", {});
+    // @ts-ignore
+    tokensWallet[actual.id] = {};
+    senderWallet.setAttribute<INFTTokens>("nft.base.tokenIds", tokensWallet);
+    walletRepository.index(senderWallet);
 });
 
 afterEach(() => {
@@ -84,7 +90,7 @@ describe("Test asset controller", () => {
         const response = (await assetController.index(request, undefined)) as PaginatedResponse;
         expect(response.results[0]).toStrictEqual({
             id: actual.id,
-            senderPublicKey: Identities.PublicKey.fromPassphrase(passphrases[0]),
+            ownerPublicKey: Identities.PublicKey.fromPassphrase(passphrases[0]),
             collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             attributes: {
                 name: "card name",
@@ -132,7 +138,7 @@ describe("Test asset controller", () => {
 
         expect(response.data).toStrictEqual({
             id: actual.id,
-            senderPublicKey: senderWallet.publicKey,
+            ownerPublicKey: senderWallet.publicKey,
             collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             attributes: {
                 name: "card name",
@@ -158,7 +164,7 @@ describe("Test asset controller", () => {
         const response = (await assetController.showByAsset(request, undefined)) as PaginatedResponse;
         expect(response.results[0]).toStrictEqual({
             id: actual.id,
-            senderPublicKey: Identities.PublicKey.fromPassphrase(passphrases[0]),
+            ownerPublicKey: Identities.PublicKey.fromPassphrase(passphrases[0]),
             collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             attributes: {
                 name: "card name",

--- a/packages/nft-base-api/__tests__/unit/controllers/collections.test.ts
+++ b/packages/nft-base-api/__tests__/unit/controllers/collections.test.ts
@@ -10,7 +10,7 @@ import { ITransaction } from "@arkecosystem/crypto/src/interfaces";
 import { configManager } from "@arkecosystem/crypto/src/managers";
 import Hapi from "@hapi/hapi";
 import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
-import { INFTCollections } from "@protokol/nft-base-transactions/src/interfaces";
+import { INFTCollections, INFTTokens } from "@protokol/nft-base-transactions/src/interfaces";
 
 import { buildSenderWallet, initApp, ItemResponse, PaginatedResponse } from "../__support__";
 import { CollectionsController } from "../../../src/controllers/collections";
@@ -251,6 +251,12 @@ describe("Test collection controller", () => {
             .sign(passphrases[0])
             .build();
 
+        const tokensWallet = senderWallet.getAttribute<INFTTokens>("nft.base.tokenIds", {});
+        // @ts-ignore
+        tokensWallet[actual.id] = {};
+        senderWallet.setAttribute<INFTTokens>("nft.base.tokenIds", tokensWallet);
+        walletRepository.index(senderWallet);
+
         transactionHistoryService.listByCriteria.mockResolvedValueOnce({ rows: [actual.data] });
 
         const request: Hapi.Request = {
@@ -265,7 +271,7 @@ describe("Test collection controller", () => {
         const response = (await collectionController.showAssetsByCollectionId(request, undefined)) as PaginatedResponse;
         expect(response.results[0]).toStrictEqual({
             id: actual.id,
-            senderPublicKey: actual.data.senderPublicKey,
+            ownerPublicKey: actual.data.senderPublicKey,
             collectionId: "5fe521beb05636fbe16d2eb628d835e6eb635070de98c3980c9ea9ea4496061a",
             attributes: {
                 number: 5,

--- a/packages/nft-base-api/src/resources/assets.ts
+++ b/packages/nft-base-api/src/resources/assets.ts
@@ -1,8 +1,13 @@
 import { Contracts } from "@arkecosystem/core-api";
-import { Container } from "@arkecosystem/core-kernel";
+import { Container, Contracts as CoreContracts } from "@arkecosystem/core-kernel";
+import { Indexers } from "@protokol/nft-base-transactions";
 
 @Container.injectable()
 export class AssetResource implements Contracts.Resource {
+    @Container.inject(Container.Identifiers.WalletRepository)
+    @Container.tagged("state", "blockchain")
+    private readonly walletRepository!: CoreContracts.State.WalletRepository;
+
     /**
      * Return the raw representation of the resource.
      *
@@ -24,7 +29,8 @@ export class AssetResource implements Contracts.Resource {
     public transform(resource): object {
         return {
             id: resource.id,
-            senderPublicKey: resource.senderPublicKey,
+            ownerPublicKey: this.walletRepository.findByIndex(Indexers.NFTIndexers.NFTTokenIndexer, resource.id)
+                .publicKey,
             ...resource.asset.nftToken,
         };
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Renamed `senderPublicKey` to `ownerPublicKey` in assets.


<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

