### PR TITLE
fix(nft-exchange-transactions): prevent bidding on own auction items

### DIFF
--- a/packages/nft-exchange-transactions/src/errors.ts
+++ b/packages/nft-exchange-transactions/src/errors.ts
@@ -53,13 +53,19 @@ export class NFTExchangeBidAuctionExpired extends Errors.TransactionError {
 
 export class NFTExchangeBidNotEnoughFounds extends Errors.TransactionError {
     public constructor() {
-        super(`Failed to apply transaction, because wallet doesn't have enough founds.`);
+        super(`Failed to apply transaction, because wallet doesn't have enough funds.`);
     }
 }
 
 export class NFTExchangeBidStartAmountToLow extends Errors.TransactionError {
     public constructor() {
         super(`Failed to apply transaction, because bid amount is to low.`);
+    }
+}
+
+export class NFTExchangeBidCannotBidOwnItem extends Errors.TransactionError {
+    public constructor() {
+        super(`Failed to apply transaction, because it is not allowed to bid on own auction.`);
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Add checks to prevent auction issuer to bid on own auction items. Closes #53 

### Why are these changes necessary?

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

