### PR TITLE
fix(nft-base-transactions): remove unnecessary indexing, which caused burn revert to fail

### DIFF
--- a/packages/nft-base-transactions/src/handlers/nft-burn.ts
+++ b/packages/nft-base-transactions/src/handlers/nft-burn.ts
@@ -173,7 +173,6 @@ export class NFTBurnHandler extends NFTBaseTransactionHandler {
         genesisWallet.setAttribute<INFTCollections>("nft.base.collections", collectionsWallet);
 
         walletRepository.index(sender);
-        walletRepository.index(genesisWallet);
     }
 
     public async applyToRecipient(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Removed unnecessary indexing, which caused revert to fail

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

