### PR TITLE
fix(nft-exchange-transactions): correctly update lockedBalance when canceling an auction

### DIFF
--- a/packages/nft-exchange-transactions/src/handlers/nft-auction-cancel.ts
+++ b/packages/nft-exchange-transactions/src/handlers/nft-auction-cancel.ts
@@ -53,7 +53,7 @@ export class NFTAuctionCancelHandler extends NFTExchangeTransactionHandler {
                     "nft.exchange.lockedBalance",
                     Utils.BigNumber.ZERO,
                 );
-                bidWallet.setAttribute<Utils.BigNumber>("nft.exchange.lockedBalance", lockedBalance.plus(bidAmount));
+                bidWallet.setAttribute<Utils.BigNumber>("nft.exchange.lockedBalance", lockedBalance.minus(bidAmount));
 
                 this.walletRepository.forgetByIndex(NFTExchangeIndexers.BidIndexer, bid.id);
                 this.walletRepository.index(bidWallet);
@@ -134,7 +134,7 @@ export class NFTAuctionCancelHandler extends NFTExchangeTransactionHandler {
                 "nft.exchange.lockedBalance",
                 Utils.BigNumber.ZERO,
             );
-            bidWallet.setAttribute<Utils.BigNumber>("nft.exchange.lockedBalance", lockedBalance.plus(bidAmount));
+            bidWallet.setAttribute<Utils.BigNumber>("nft.exchange.lockedBalance", lockedBalance.minus(bidAmount));
 
             this.walletRepository.forgetByIndex(NFTExchangeIndexers.BidIndexer, bid.id);
             this.walletRepository.index(bidWallet);
@@ -165,17 +165,15 @@ export class NFTAuctionCancelHandler extends NFTExchangeTransactionHandler {
             asset: { nftBid: { auctionId: nftAuctionCancelAsset.auctionId } },
         });
         const activeBids: string[] = [];
-        if (bidTransactions) {
-            for (const bidTransaction of bidTransactions) {
-                const bidCancel = await this.transactionHistoryService.findOneByCriteria({
-                    typeGroup: NFTExchangeEnums.NFTExchangeTransactionsTypeGroup,
-                    type: NFTExchangeEnums.NFTTransactionTypes.NFTBidCancel,
-                    asset: { nftBidCancel: { bidId: bidTransaction.id } },
-                });
-                if (!bidCancel) {
-                    // @ts-ignore
-                    activeBids.push(bidTransaction.id);
-                }
+        for (const bidTransaction of bidTransactions) {
+            const bidCancel = await this.transactionHistoryService.findOneByCriteria({
+                typeGroup: NFTExchangeEnums.NFTExchangeTransactionsTypeGroup,
+                type: NFTExchangeEnums.NFTTransactionTypes.NFTBidCancel,
+                asset: { nftBidCancel: { bidId: bidTransaction.id } },
+            });
+            if (!bidCancel) {
+                // @ts-ignore
+                activeBids.push(bidTransaction.id);
             }
         }
 
@@ -189,7 +187,7 @@ export class NFTAuctionCancelHandler extends NFTExchangeTransactionHandler {
                 "nft.exchange.lockedBalance",
                 Utils.BigNumber.ZERO,
             );
-            bidWallet.setAttribute<Utils.BigNumber>("nft.exchange.lockedBalance", lockedBalance.minus(bidAmount));
+            bidWallet.setAttribute<Utils.BigNumber>("nft.exchange.lockedBalance", lockedBalance.plus(bidAmount));
 
             this.walletRepository.index(bidWallet);
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Correctly update `lockedBalance` attribute when canceling an auction together with bids. Closes https://github.com/protokol/nft-plugins/issues/70


<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->

