### PR TITLE
fix(exchange-transactions): allow-bid-cancel-only-to-issuer

### DIFF
--- a/packages/nft-exchange-transactions/src/errors.ts
+++ b/packages/nft-exchange-transactions/src/errors.ts
@@ -88,6 +88,12 @@ export class NFTExchangeBidCancelBidCanceled extends Errors.TransactionError {
     }
 }
 
+export class NFTExchangeBidCancelCannotCancelOtherBids extends Errors.TransactionError {
+    public constructor() {
+        super(`Failed to apply transaction, because it is not allowed to cancel other user's bids.`);
+    }
+}
+
 // Accept trade errors
 export class NFTExchangeAcceptTradeWalletCannotTrade extends Errors.TransactionError {
     public constructor() {

--- a/packages/nft-exchange-transactions/src/handlers/nft-bid-cancel.ts
+++ b/packages/nft-exchange-transactions/src/handlers/nft-bid-cancel.ts
@@ -8,6 +8,7 @@ import {
     NFTExchangeBidCancelAuctionCanceledOrAccepted,
     NFTExchangeBidCancelBidCanceled,
     NFTExchangeBidCancelBidDoesNotExists,
+    NFTExchangeBidCancelCannotCancelOtherBids,
 } from "../errors";
 import { NFTExchangeApplicationEvents } from "../events";
 import { INFTAuctions } from "../interfaces";
@@ -84,6 +85,10 @@ export class NFTBidCancelHandler extends NFTExchangeTransactionHandler {
             bidTransaction.type !== Enums.NFTTransactionTypes.NFTBid
         ) {
             throw new NFTExchangeBidCancelBidDoesNotExists();
+        }
+
+        if (sender.publicKey !== bidTransaction.senderPublicKey) {
+            throw new NFTExchangeBidCancelCannotCancelOtherBids();
         }
 
         const auctionTransaction = await this.transactionRepository.findById(bidTransaction.asset.nftBid.auctionId);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Allow bid issuer to cancel only belonging bids. Closes https://github.com/protokol/nft-plugins/issues/69

### Why are these changes necessary?
To prevent other users to cancel bids that don't belong to them.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

