### PR TITLE
refactor(nft-client): export as namespace and add 'nft' path to endpoints

### DIFF
--- a/packages/nft-client/src/index.ts
+++ b/packages/nft-client/src/index.ts
@@ -1,5 +1,5 @@
 export * from "./nft-connection";
-export * from "./resources/base";
-export * from "./resources/exchange";
-export * from "./resourcesTypes/base";
-export * from "./resourcesTypes/exchange";
+export * as BaseResources from "./resources/base";
+export * as ExchangeResources from "./resources/exchange";
+export * as BaseResourcesTypes from "./resourcesTypes/base";
+export * as ExchangeResourcesTypes from "./resourcesTypes/exchange";

--- a/packages/nft-client/src/resources/base/assets.ts
+++ b/packages/nft-client/src/resources/base/assets.ts
@@ -9,21 +9,21 @@ import {
 
 export class Assets extends Resource {
     public async all(query?: AllAssetsQuery): Promise<ApiResponseWithPagination<AssetsResource[]>> {
-        return this.sendGet("assets", query);
+        return this.sendGet("nft/assets", query);
     }
 
     public async get(id: string): Promise<ApiResponse<AssetsResource>> {
-        return this.sendGet(`assets/${id}`);
+        return this.sendGet(`nft/assets/${id}`);
     }
 
     public async wallet(id: string): Promise<ApiResponse<AssetsWallet>> {
-        return this.sendGet(`assets/${id}/wallets`);
+        return this.sendGet(`nft/assets/${id}/wallets`);
     }
 
     public async searchByAsset(
         payload: SearchAssetApiBody,
         query?: ApiQuery,
     ): Promise<ApiResponseWithPagination<AssetsResource[]>> {
-        return this.sendPost("assets/search", payload, query);
+        return this.sendPost("nft/assets/search", payload, query);
     }
 }

--- a/packages/nft-client/src/resources/base/burns.ts
+++ b/packages/nft-client/src/resources/base/burns.ts
@@ -4,10 +4,10 @@ import { AllBurnsQuery, Burns as BurnsResource } from "../../resourcesTypes/base
 
 export class Burns extends Resource {
     public async all(query?: AllBurnsQuery): Promise<ApiResponseWithPagination<BurnsResource[]>> {
-        return this.sendGet("burns", query);
+        return this.sendGet("nft/burns", query);
     }
 
     public async get(id: string): Promise<ApiResponse<BurnsResource>> {
-        return this.sendGet(`burns/${id}`);
+        return this.sendGet(`nft/burns/${id}`);
     }
 }

--- a/packages/nft-client/src/resources/base/collections.ts
+++ b/packages/nft-client/src/resources/base/collections.ts
@@ -10,32 +10,32 @@ import {
 
 export class Collections extends Resource {
     public async all(query?: AllCollectionsQuery): Promise<ApiResponseWithPagination<CollectionsResource[]>> {
-        return this.sendGet("collections", query);
+        return this.sendGet("nft/collections", query);
     }
 
     public async get(id: string): Promise<ApiResponse<CollectionsResource>> {
-        return this.sendGet(`collections/${id}`);
+        return this.sendGet(`nft/collections/${id}`);
     }
 
     public async getSchema(id: string): Promise<ApiResponse<Schema>> {
-        return this.sendGet(`collections/${id}/schema`);
+        return this.sendGet(`nft/collections/${id}/schema`);
     }
 
     public async wallet(id: string): Promise<ApiResponse<CollectionsWallet>> {
-        return this.sendGet(`collections/${id}/wallets`);
+        return this.sendGet(`nft/collections/${id}/wallets`);
     }
 
     public async searchByCollections(
         payload: SearchCollectionsApiBody,
         query?: AllCollectionsQuery,
     ): Promise<ApiResponseWithPagination<CollectionsResource[]>> {
-        return this.sendPost("collections/search", payload, query);
+        return this.sendPost("nft/collections/search", payload, query);
     }
 
     public async assetByCollectionId(
         id: string,
         query?: AllCollectionsQuery,
     ): Promise<ApiResponseWithPagination<CollectionsAsset[]>> {
-        return this.sendGet(`collections/${id}/assets`, query);
+        return this.sendGet(`nft/collections/${id}/assets`, query);
     }
 }

--- a/packages/nft-client/src/resources/base/configurations.ts
+++ b/packages/nft-client/src/resources/base/configurations.ts
@@ -4,6 +4,6 @@ import { BaseConfigurations as ConfigurationsResource } from "../../resourcesTyp
 
 export class Configurations extends Resource {
     public async index(): Promise<ApiResponse<ConfigurationsResource>> {
-        return this.sendGet("configurations");
+        return this.sendGet("nft/configurations");
     }
 }

--- a/packages/nft-client/src/resources/base/transfers.ts
+++ b/packages/nft-client/src/resources/base/transfers.ts
@@ -5,10 +5,10 @@ import { AllTransfersQuery } from "../../resourcesTypes/base";
 
 export class Transfers extends Resource {
     public async all(query?: AllTransfersQuery): Promise<ApiResponseWithPagination<TransfersResource[]>>{
-        return this.sendGet("transfers");
+        return this.sendGet("nft/transfers");
     }
 
     public async get(id: string): Promise<ApiResponse<TransfersResource>> {
-        return this.sendGet(`transfers/${id}`);
+        return this.sendGet(`nft/transfers/${id}`);
     }
 }

--- a/packages/nft-client/src/resources/exchange/auctions.ts
+++ b/packages/nft-client/src/resources/exchange/auctions.ts
@@ -12,31 +12,31 @@ import {
 
 export class Auctions extends Resource {
     public async getAllAuctions(query?: AllAuctionsQuery): Promise<ApiResponseWithPagination<AuctionsResource[]>> {
-        return this.sendGet("exchange/auctions");
+        return this.sendGet("nft/exchange/auctions");
     }
 
     public async getAuctionById(id: string): Promise<ApiResponse<AuctionsResource>> {
-        return this.sendGet(`exchange/auctions/${id}`);
+        return this.sendGet(`nft/exchange/auctions/${id}`);
     }
 
     public async getAuctionsWallets(id: string): Promise<ApiResponse<AuctionsWallet>> {
-        return this.sendGet(`exchange/auctions/${id}/wallets`);
+        return this.sendGet(`nft/exchange/auctions/${id}/wallets`);
     }
 
     public async searchByAsset(
         payload: SearchAuctionsApiBody,
         query?: SearchAuctionsApiQuery,
     ): Promise<ApiResponseWithPagination<AuctionsResource[]>> {
-        return this.sendPost("exchange/auctions/search", payload, query);
+        return this.sendPost("nft/exchange/auctions/search", payload, query);
     }
 
     public async getAllCanceledAuctions(
         query?: AllAuctionCanceledQuery,
     ): Promise<ApiResponseWithPagination<AuctionCanceled[]>> {
-        return this.sendGet("exchange/auctions/canceled");
+        return this.sendGet("nft/exchange/auctions/canceled");
     }
 
     public async getCanceledAuctionById(id: string): Promise<ApiResponse<AuctionCanceled>> {
-        return this.sendGet(`exchange/auctions/canceled/${id}`);
+        return this.sendGet(`nft/exchange/auctions/canceled/${id}`);
     }
 }

--- a/packages/nft-client/src/resources/exchange/bids.ts
+++ b/packages/nft-client/src/resources/exchange/bids.ts
@@ -12,28 +12,28 @@ import {
 
 export class Bids extends Resource {
     public async getAllBids(query?: AllBidsQuery): Promise<ApiResponse<BidsResource>> {
-        return this.sendGet("exchange/bids");
+        return this.sendGet("nft/exchange/bids");
     }
 
     public async getBidById(id: string): Promise<ApiResponse<BidsResource>> {
-        return this.sendGet(`exchange/bids/${id}`);
+        return this.sendGet(`nft/exchange/bids/${id}`);
     }
 
     public async getBidsWallets(id: string): Promise<ApiResponse<BidsWallet>> {
-        return this.sendGet(`exchange/bids/${id}/wallets`);
+        return this.sendGet(`nft/exchange/bids/${id}/wallets`);
     }
 
     public async searchByBid(
         payload: SearchBidsApiBody,
         query?: SearchBidsApiQuery,
     ): Promise<ApiResponseWithPagination<BidsResource[]>> {
-        return this.sendPost("exchange/bids/search", payload, query);
+        return this.sendPost("nft/exchange/bids/search", payload, query);
     }
 
     public async getAllCanceledBids(query?: AllBidsCanceledQuery): Promise<ApiResponse<BidCanceled>> {
-        return this.sendGet("exchange/bids/canceled");
+        return this.sendGet("nft/exchange/bids/canceled");
     }
     public async getCanceledBidById(id: string): Promise<ApiResponse<BidCanceled>> {
-        return this.sendGet(`exchange/bids/canceled/${id}`);
+        return this.sendGet(`nft/exchange/bids/canceled/${id}`);
     }
 }

--- a/packages/nft-client/src/resources/exchange/configurations.ts
+++ b/packages/nft-client/src/resources/exchange/configurations.ts
@@ -4,6 +4,6 @@ import { ExchangeConfigurations as ConfigurationsResource } from "../../resource
 
 export class Configurations extends Resource {
     public async index(): Promise<ApiResponse<ConfigurationsResource>> {
-        return this.sendGet("exchange/configurations");
+        return this.sendGet("nft/exchange/configurations");
     }
 }

--- a/packages/nft-client/src/resources/exchange/trades.ts
+++ b/packages/nft-client/src/resources/exchange/trades.ts
@@ -10,17 +10,17 @@ import {
 
 export class Trades extends Resource {
     public async all(query?: AllTradesQuery): Promise<ApiResponse<TradesResource>> {
-        return this.sendGet("exchange/trades");
+        return this.sendGet("nft/exchange/trades");
     }
 
     public async get(id: string): Promise<ApiResponse<TradeById>> {
-        return this.sendGet(`exchange/trades/${id}`);
+        return this.sendGet(`nft/exchange/trades/${id}`);
     }
 
     public async search(
         payload: SearchTradesApiBody,
         query?: SearchTradesApiQuery,
     ): Promise<ApiResponseWithPagination<TradesResource[]>> {
-        return this.sendPost("exchange/trades/search", payload, query);
+        return this.sendPost("nft/exchange/trades/search", payload, query);
     }
 }


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
- Export as namespace syntax
- Add `nft` to endpoint paths

### Why are these changes necessary?
Beffore adding `nft` to endpoints user had to use NFTConnection like this:
`new NFTConnection("http://localhost:4003/api/nft");`
now it just specify api, like this 
`new NFTConnection("http://localhost:4003/api");`

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

