### PR TITLE
feat(nft-base-transactions): prevent additional schema props by default

### DIFF
--- a/packages/nft-base-transactions/src/handlers/nft-create.ts
+++ b/packages/nft-base-transactions/src/handlers/nft-create.ts
@@ -92,11 +92,11 @@ export class NFTCreateHandler extends NFTBaseTransactionHandler {
             }
         }
 
-        const ajv = new Ajv({
-            allErrors: true,
-            removeAdditional: true,
+        const ajv = new Ajv({ allErrors: true });
+        const validate = ajv.compile({
+            additionalProperties: false,
+            ...genesisWalletCollection.nftCollectionAsset.jsonSchema,
         });
-        const validate = ajv.compile(genesisWalletCollection.nftCollectionAsset.jsonSchema);
         if (!validate(transaction.data.asset.nftToken.attributes)) {
             throw new NFTBaseSchemaDoesNotMatch();
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
When creating an asset change the behavior of default validation from allowing any additional props to throw an error when adding props that are not defined/allowed in JSON schema.

### Why are these changes necessary?
To change the default behavior to allow only properties defined/allowed in JSON schema when creating an asset.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

