### PR TITLE
feat(nft-base-transactions): cache compiled validation schema

### DIFF
--- a/packages/nft-base-api/__tests__/unit/__support__/index.ts
+++ b/packages/nft-base-api/__tests__/unit/__support__/index.ts
@@ -1,5 +1,7 @@
 import { Application, Container, Contracts, Providers, Services } from "@arkecosystem/core-kernel";
 import { Identifiers } from "@arkecosystem/core-kernel/src/ioc";
+import { MemoryCacheStore } from "@arkecosystem/core-kernel/src/services/cache/drivers/memory";
+import { NullEventDispatcher } from "@arkecosystem/core-kernel/src/services/events/drivers/null";
 import { Wallets } from "@arkecosystem/core-state";
 import { publicKeysIndexer } from "@arkecosystem/core-state/src/wallets/indexers/indexers";
 import passphrases from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
@@ -85,6 +87,10 @@ export const initApp = (): Application => {
 
     app.bind(Identifiers.TransactionHandlerProvider).to(TransactionHandlerProvider).inSingletonScope();
     app.bind(Identifiers.TransactionHandlerRegistry).to(TransactionHandlerRegistry).inSingletonScope();
+
+    app.bind(Identifiers.EventDispatcherService).to(NullEventDispatcher).inSingletonScope();
+
+    app.bind(Container.Identifiers.CacheService).to(MemoryCacheStore).inSingletonScope();
 
     app.bind(Identifiers.TransactionHandler).to(Handlers.NFTRegisterCollectionHandler);
     app.bind(Identifiers.TransactionHandler).to(Handlers.NFTCreateHandler);

--- a/packages/nft-base-transactions/__tests__/unit/__support__/app.ts
+++ b/packages/nft-base-transactions/__tests__/unit/__support__/app.ts
@@ -1,5 +1,6 @@
 import { Application, Container, Contracts, Providers, Services } from "@arkecosystem/core-kernel";
 import { Identifiers } from "@arkecosystem/core-kernel/src/ioc";
+import { MemoryCacheStore } from "@arkecosystem/core-kernel/src/services/cache/drivers/memory";
 import { NullEventDispatcher } from "@arkecosystem/core-kernel/src/services/events/drivers/null";
 import { Wallets } from "@arkecosystem/core-state";
 import { StateStore } from "@arkecosystem/core-state/src/stores/state";
@@ -11,6 +12,7 @@ import {
     usernamesIndexer,
 } from "@arkecosystem/core-state/src/wallets/indexers/indexers";
 import { Mocks } from "@arkecosystem/core-test-framework";
+import { Generators } from "@arkecosystem/core-test-framework/src";
 import { Collator } from "@arkecosystem/core-transaction-pool/src";
 import {
     ApplyTransactionAction,
@@ -28,17 +30,16 @@ import { One, Two } from "@arkecosystem/core-transactions/src/handlers";
 import { TransactionHandlerProvider } from "@arkecosystem/core-transactions/src/handlers/handler-provider";
 import { TransactionHandlerRegistry } from "@arkecosystem/core-transactions/src/handlers/handler-registry";
 import { Identities, Managers, Utils } from "@arkecosystem/crypto";
+import { configManager } from "@arkecosystem/crypto/src/managers";
 
 import { transactionRepository } from "../__mocks__/transaction-repository";
-import { Generators } from "@arkecosystem/core-test-framework/src";
-import { configManager } from "@arkecosystem/crypto/src/managers";
-import { nftCollectionIndexer, nftIndexer, NFTIndexers } from "../../../src/wallet-indexes";
 import {
     NFTBurnHandler,
     NFTCreateHandler,
     NFTRegisterCollectionHandler,
     NFTTransferHandler,
 } from "../../../src/handlers";
+import { nftCollectionIndexer, nftIndexer, NFTIndexers } from "../../../src/wallet-indexes";
 
 const logger = {
     notice: jest.fn(),
@@ -197,6 +198,8 @@ export const initApp = (): Application => {
     app.bind(Identifiers.TransactionHandler).to(NFTCreateHandler);
     app.bind(Identifiers.TransactionHandler).to(NFTBurnHandler);
     app.bind(Identifiers.TransactionHandler).to(NFTTransferHandler);
+
+    app.bind(Container.Identifiers.CacheService).to(MemoryCacheStore).inSingletonScope();
 
     return app;
 };

--- a/packages/nft-base-transactions/__tests__/unit/handlers/nft-create.test.ts
+++ b/packages/nft-base-transactions/__tests__/unit/handlers/nft-create.test.ts
@@ -19,6 +19,7 @@ import {
     NFTBaseSenderPublicKeyDoesNotExists,
 } from "../../../src/errors";
 import { NFTApplicationEvents } from "../../../src/events";
+import { NFTRegisterCollectionHandler } from "../../../src/handlers";
 import { INFTCollections, INFTTokens } from "../../../src/interfaces";
 import { NFTIndexers } from "../../../src/wallet-indexes";
 import { collectionWalletCheck, deregisterTransactions } from "../utils/utils";
@@ -60,7 +61,9 @@ const nftCollectionAsset: NFTInterfaces.NFTCollectionAsset = {
     },
 };
 
-beforeEach(() => {
+const collectionId = "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61";
+
+beforeEach(async () => {
     app = initApp();
 
     wallet = buildWallet(app, passphrases[0]);
@@ -78,10 +81,19 @@ beforeEach(() => {
     );
     const collectionsWallet = wallet.getAttribute<INFTCollections>("nft.base.collections", {});
 
-    collectionsWallet["8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61"] = {
+    collectionsWallet[collectionId] = {
         currentSupply: 0,
         nftCollectionAsset: nftCollectionAsset,
     };
+
+    const nftRegisterHandler = (transactionHandlerRegistry.getRegisteredHandlerByType(
+        Transactions.InternalTransactionType.from(
+            Enums.NFTBaseTransactionTypes.NFTRegisterCollection,
+            Enums.NFTBaseTransactionGroup,
+        ),
+        2,
+    ) as unknown) as NFTRegisterCollectionHandler;
+    await nftRegisterHandler.persistSchemaValidation(collectionId, nftCollectionAsset.jsonSchema);
 
     wallet.setAttribute("nft.base.collections", collectionsWallet);
 
@@ -89,7 +101,7 @@ beforeEach(() => {
 
     actual = new NFTBuilders.NFTCreateBuilder()
         .NFTCreateToken({
-            collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
+            collectionId,
             attributes: {
                 name: "card name",
                 damage: 3,
@@ -118,12 +130,7 @@ describe("NFT Create tests", () => {
             // @ts-ignore
             expect(wallet.getAttribute<INFTTokens>("nft.base.tokenIds")[actual.id]).toBeObject();
 
-            collectionWalletCheck(
-                wallet,
-                "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
-                1,
-                nftCollectionAsset,
-            );
+            collectionWalletCheck(wallet, collectionId, 1, nftCollectionAsset);
 
             // @ts-ignore
             expect(walletRepository.findByIndex(NFTIndexers.NFTTokenIndexer, actual.id)).toStrictEqual(wallet);
@@ -135,7 +142,7 @@ describe("NFT Create tests", () => {
 
             const actualTwo = new NFTBuilders.NFTCreateBuilder()
                 .NFTCreateToken({
-                    collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
+                    collectionId,
                     attributes: {
                         name: "card name",
                         damage: 3,
@@ -152,12 +159,7 @@ describe("NFT Create tests", () => {
             });
             await expect(nftCreateHandler.bootstrap()).toResolve();
 
-            collectionWalletCheck(
-                wallet,
-                "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
-                1,
-                nftCollectionAsset,
-            );
+            collectionWalletCheck(wallet, collectionId, 1, nftCollectionAsset);
 
             // @ts-ignore
             expect(secondWallet.getAttribute<INFTTokens>("nft.base.tokenIds")[actualTwo.id]).toBeObject();
@@ -174,7 +176,7 @@ describe("NFT Create tests", () => {
 
         it("should not throw if it is allowed issuer", async () => {
             const collectionsWallet = wallet.getAttribute<INFTCollections>("nft.base.collections", {});
-            collectionsWallet["8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61"] = {
+            collectionsWallet[collectionId] = {
                 currentSupply: 0,
                 nftCollectionAsset: {
                     ...nftCollectionAsset,
@@ -195,7 +197,7 @@ describe("NFT Create tests", () => {
 
         it("should throw NFTMaximumSupplyError", async () => {
             const collectionsWallet = wallet.getAttribute<INFTCollections>("nft.base.collections", {});
-            collectionsWallet["8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61"] = {
+            collectionsWallet[collectionId] = {
                 currentSupply: 100,
                 nftCollectionAsset: nftCollectionAsset,
             };
@@ -229,7 +231,7 @@ describe("NFT Create tests", () => {
         it("should throw NFTSchemaDoesNotMatch", async () => {
             const actual = new NFTBuilders.NFTCreateBuilder()
                 .NFTCreateToken({
-                    collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
+                    collectionId,
                     attributes: {
                         name: "a",
                     },
@@ -245,7 +247,7 @@ describe("NFT Create tests", () => {
 
         it("should throw NFTSenderPublicKeyDoesNotExists", async () => {
             const collectionsWallet = wallet.getAttribute<INFTCollections>("nft.base.collections", {});
-            collectionsWallet["8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61"] = {
+            collectionsWallet[collectionId] = {
                 currentSupply: 100,
                 nftCollectionAsset: {
                     name: "Nft card",
@@ -275,7 +277,7 @@ describe("NFT Create tests", () => {
 
             const actual = new NFTBuilders.NFTCreateBuilder()
                 .NFTCreateToken({
-                    collectionId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
+                    collectionId,
                     attributes: {
                         name: "card name",
                         damage: 3,
@@ -313,12 +315,7 @@ describe("NFT Create tests", () => {
             // @ts-ignore
             expect(wallet.getAttribute<INFTTokens>("nft.base.tokenIds")[actual.id]).toBeObject();
 
-            collectionWalletCheck(
-                wallet,
-                "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
-                1,
-                nftCollectionAsset,
-            );
+            collectionWalletCheck(wallet, collectionId, 1, nftCollectionAsset);
 
             // @ts-ignore
             expect(walletRepository.findByIndex(NFTIndexers.NFTTokenIndexer, actual.id)).toStrictEqual(wallet);
@@ -332,12 +329,7 @@ describe("NFT Create tests", () => {
             // @ts-ignore
             expect(wallet.getAttribute<INFTTokens>("nft.base.tokenIds")[actual.id]).toBeUndefined();
 
-            collectionWalletCheck(
-                wallet,
-                "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
-                0,
-                nftCollectionAsset,
-            );
+            collectionWalletCheck(wallet, collectionId, 0, nftCollectionAsset);
 
             // @ts-ignore
             expect(walletRepository.getIndex(NFTIndexers.NFTTokenIndexer).get(actual.id)).toBeUndefined();

--- a/packages/nft-base-transactions/__tests__/unit/handlers/nft-create.test.ts
+++ b/packages/nft-base-transactions/__tests__/unit/handlers/nft-create.test.ts
@@ -93,7 +93,7 @@ beforeEach(async () => {
         ),
         2,
     ) as unknown) as NFTRegisterCollectionHandler;
-    await nftRegisterHandler.persistSchemaValidation(collectionId, nftCollectionAsset.jsonSchema);
+    await nftRegisterHandler.compileAndPersistSchema(collectionId, nftCollectionAsset.jsonSchema);
 
     wallet.setAttribute("nft.base.collections", collectionsWallet);
 

--- a/packages/nft-base-transactions/src/handlers/nft-create.ts
+++ b/packages/nft-base-transactions/src/handlers/nft-create.ts
@@ -98,7 +98,7 @@ export class NFTCreateHandler extends NFTBaseTransactionHandler {
         }
 
         const validate = await this.tokenSchemaValidator.get(nftTokenAsset.collectionId);
-        if (!validate || !validate(transaction.data.asset.nftToken.attributes)) {
+        if (!validate?.(transaction.data.asset.nftToken.attributes)) {
             throw new NFTBaseSchemaDoesNotMatch();
         }
 

--- a/packages/nft-base-transactions/src/handlers/nft-create.ts
+++ b/packages/nft-base-transactions/src/handlers/nft-create.ts
@@ -3,7 +3,6 @@ import { Handlers } from "@arkecosystem/core-transactions";
 import { Interfaces, Transactions } from "@arkecosystem/crypto";
 import { Interfaces as NFTInterfaces } from "@protokol/nft-base-crypto";
 import { Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
-import Ajv from "ajv";
 
 import {
     NFTBaseCollectionDoesNotExists,
@@ -17,10 +16,16 @@ import { NFTIndexers } from "../wallet-indexes";
 import { NFTBaseTransactionHandler } from "./nft-base-handler";
 import { NFTRegisterCollectionHandler } from "./nft-register-collection";
 
+const pluginName = require("../../package.json").name;
+
 @Container.injectable()
 export class NFTCreateHandler extends NFTBaseTransactionHandler {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
     private readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
+
+    @Container.inject(Container.Identifiers.CacheService)
+    @Container.tagged("cache", pluginName)
+    private readonly tokenSchemaValidator!: Contracts.Kernel.CacheStore<string, any>;
 
     public getConstructor(): Transactions.TransactionConstructor {
         return NFTTransactions.NFTCreateTransaction;
@@ -92,12 +97,8 @@ export class NFTCreateHandler extends NFTBaseTransactionHandler {
             }
         }
 
-        const ajv = new Ajv({ allErrors: true });
-        const validate = ajv.compile({
-            additionalProperties: false,
-            ...genesisWalletCollection.nftCollectionAsset.jsonSchema,
-        });
-        if (!validate(transaction.data.asset.nftToken.attributes)) {
+        const validate = await this.tokenSchemaValidator.get(nftTokenAsset.collectionId);
+        if (!validate || !validate(transaction.data.asset.nftToken.attributes)) {
             throw new NFTBaseSchemaDoesNotMatch();
         }
 

--- a/packages/nft-base-transactions/src/handlers/nft-create.ts
+++ b/packages/nft-base-transactions/src/handlers/nft-create.ts
@@ -25,7 +25,7 @@ export class NFTCreateHandler extends NFTBaseTransactionHandler {
 
     @Container.inject(Container.Identifiers.CacheService)
     @Container.tagged("cache", pluginName)
-    private readonly tokenSchemaValidator!: Contracts.Kernel.CacheStore<string, any>;
+    private readonly tokenSchemaValidatorCache!: Contracts.Kernel.CacheStore<string, any>;
 
     public getConstructor(): Transactions.TransactionConstructor {
         return NFTTransactions.NFTCreateTransaction;
@@ -97,7 +97,7 @@ export class NFTCreateHandler extends NFTBaseTransactionHandler {
             }
         }
 
-        const validate = await this.tokenSchemaValidator.get(nftTokenAsset.collectionId);
+        const validate = await this.tokenSchemaValidatorCache.get(nftTokenAsset.collectionId);
         if (!validate?.(transaction.data.asset.nftToken.attributes)) {
             throw new NFTBaseSchemaDoesNotMatch();
         }

--- a/packages/nft-base-transactions/src/handlers/nft-register-collection.ts
+++ b/packages/nft-base-transactions/src/handlers/nft-register-collection.ts
@@ -129,6 +129,7 @@ export class NFTRegisterCollectionHandler extends NFTBaseTransactionHandler {
         const collectionsWallet = senderWallet.getAttribute<INFTCollections>("nft.base.collections");
         delete collectionsWallet[transaction.data.id];
         senderWallet.setAttribute("nft.base.collections", collectionsWallet);
+        await this.tokenSchemaValidator.forget(transaction.id!);
 
         this.walletRepository.getIndex(NFTIndexers.CollectionIndexer).forget(transaction.data.id);
     }
@@ -143,7 +144,7 @@ export class NFTRegisterCollectionHandler extends NFTBaseTransactionHandler {
         // tslint:disable-next-line:no-empty
     ): Promise<void> {}
 
-    private async persistSchemaValidation(id, jsonSchema) {
+    public async persistSchemaValidation(id, jsonSchema) {
         const ajv = new Ajv({ allErrors: true });
         const validate = ajv.compile({
             additionalProperties: false,

--- a/packages/nft-base-transactions/src/service-provider.ts
+++ b/packages/nft-base-transactions/src/service-provider.ts
@@ -3,6 +3,8 @@ import { Container, Contracts, Providers } from "@arkecosystem/core-kernel";
 import { NFTBurnHandler, NFTCreateHandler, NFTRegisterCollectionHandler, NFTTransferHandler } from "./handlers";
 import { nftCollectionIndexer, nftIndexer, NFTIndexers } from "./wallet-indexes";
 
+const pluginName = require("../package.json").name;
+
 export class ServiceProvider extends Providers.ServiceProvider {
     public async register(): Promise<void> {
         this.registerIndexers();
@@ -11,6 +13,12 @@ export class ServiceProvider extends Providers.ServiceProvider {
         this.app.bind(Container.Identifiers.TransactionHandler).to(NFTCreateHandler);
         this.app.bind(Container.Identifiers.TransactionHandler).to(NFTTransferHandler);
         this.app.bind(Container.Identifiers.TransactionHandler).to(NFTBurnHandler);
+
+        const cacheFactory: any = this.app.get(Container.Identifiers.CacheFactory);
+        this.app
+            .bind(Container.Identifiers.CacheService)
+            .toConstantValue(await cacheFactory())
+            .whenTargetTagged("cache", pluginName);
     }
 
     private registerIndexers() {

--- a/packages/nft-exchange-api/__tests__/unit/__support__/index.ts
+++ b/packages/nft-exchange-api/__tests__/unit/__support__/index.ts
@@ -1,5 +1,7 @@
 import { Application, Container, Contracts, Providers, Services } from "@arkecosystem/core-kernel";
 import { Identifiers } from "@arkecosystem/core-kernel/src/ioc";
+import { MemoryCacheStore } from "@arkecosystem/core-kernel/src/services/cache/drivers/memory";
+import { NullEventDispatcher } from "@arkecosystem/core-kernel/src/services/events/drivers/null";
 import { Wallets } from "@arkecosystem/core-state";
 import { publicKeysIndexer } from "@arkecosystem/core-state/src/wallets/indexers/indexers";
 import passphrases from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
@@ -95,6 +97,10 @@ export const initApp = (): Application => {
     app.bind(Identifiers.TransactionHandler).to(ExchangeHandlers.NFTBidHandler);
     app.bind(Identifiers.TransactionHandler).to(ExchangeHandlers.NFTBidCancelHandler);
     app.bind(Identifiers.TransactionHandler).to(ExchangeHandlers.NFTAcceptTradeHandler);
+
+    app.bind(Identifiers.EventDispatcherService).to(NullEventDispatcher).inSingletonScope();
+
+    app.bind(Container.Identifiers.CacheService).to(MemoryCacheStore).inSingletonScope();
 
     app.bind<Services.Attributes.AttributeSet>(Identifiers.WalletAttributes)
         .to(Services.Attributes.AttributeSet)

--- a/packages/nft-exchange-transactions/__tests__/unit/__support__/app.ts
+++ b/packages/nft-exchange-transactions/__tests__/unit/__support__/app.ts
@@ -1,5 +1,6 @@
 import { Application, Container, Contracts, Providers, Services } from "@arkecosystem/core-kernel";
 import { Identifiers } from "@arkecosystem/core-kernel/src/ioc";
+import { MemoryCacheStore } from "@arkecosystem/core-kernel/src/services/cache/drivers/memory";
 import { NullEventDispatcher } from "@arkecosystem/core-kernel/src/services/events/drivers/null";
 import { Wallets } from "@arkecosystem/core-state";
 import { StateStore } from "@arkecosystem/core-state/src/stores/state";
@@ -192,6 +193,8 @@ export const initApp = (): Application => {
     app.bind(Identifiers.TransactionHandler).to(NFTExchangeHandlers.NFTBidHandler);
     app.bind(Identifiers.TransactionHandler).to(NFTExchangeHandlers.NFTBidCancelHandler);
     app.bind(Identifiers.TransactionHandler).to(NFTExchangeHandlers.NFTAcceptTradeHandler);
+
+    app.bind(Container.Identifiers.CacheService).to(MemoryCacheStore).inSingletonScope();
 
     app.bind<Contracts.State.WalletIndexerIndex>(Container.Identifiers.WalletRepositoryIndexerIndex).toConstantValue({
         name: Indexers.NFTIndexers.NFTTokenIndexer,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Cache the schema during schema registration and reuse the object during the `nft-create-token` calls. Closes https://github.com/protokol/nft-plugins/issues/113

### Why are these changes necessary?
The compile schema call is an expensive call and we only need to do it once. This way performance when creating token is improved.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

