### PR TITLE
chore(nft client): added timestamp interface to some client endpoints

### DIFF
--- a/packages/nft-client/src/index.ts
+++ b/packages/nft-client/src/index.ts
@@ -1,5 +1,14 @@
+import { NFTConnection } from "./nft-connection";
+
 export * from "./nft-connection";
 export * as BaseResources from "./resources/base";
 export * as ExchangeResources from "./resources/exchange";
 export * as BaseResourcesTypes from "./resourcesTypes/base";
 export * as ExchangeResourcesTypes from "./resourcesTypes/exchange";
+
+const main = async () => {
+    const connection = new NFTConnection("http://localhost:4003/api");
+    const response = connection.NFTBaseApi("collections").searchByCollections({jsonSchema: {properties: {name: {type: "string"}}}});
+    console.log((await response).body.data);
+};
+main();

--- a/packages/nft-client/src/index.ts
+++ b/packages/nft-client/src/index.ts
@@ -1,14 +1,5 @@
-import { NFTConnection } from "./nft-connection";
-
 export * from "./nft-connection";
 export * as BaseResources from "./resources/base";
 export * as ExchangeResources from "./resources/exchange";
 export * as BaseResourcesTypes from "./resourcesTypes/base";
 export * as ExchangeResourcesTypes from "./resourcesTypes/exchange";
-
-const main = async () => {
-    const connection = new NFTConnection("http://localhost:4003/api");
-    const response = connection.NFTBaseApi("collections").searchByCollections({jsonSchema: {properties: {name: {type: "string"}}}});
-    console.log((await response).body.data);
-};
-main();

--- a/packages/nft-client/src/resources/base/assets.ts
+++ b/packages/nft-client/src/resources/base/assets.ts
@@ -3,12 +3,13 @@ import { ApiQuery, ApiResponse, ApiResponseWithPagination, Resource } from "@ark
 import {
     AllAssetsQuery,
     Assets as AssetsResource,
+    AssetsTimestamp,
     AssetsWallet,
     SearchAssetApiBody,
 } from "../../resourcesTypes/base/assets";
 
 export class Assets extends Resource {
-    public async all(query?: AllAssetsQuery): Promise<ApiResponseWithPagination<AssetsResource[]>> {
+    public async all(query?: AllAssetsQuery): Promise<ApiResponseWithPagination<AssetsTimestamp[]>> {
         return this.sendGet("nft/assets", query);
     }
 
@@ -23,7 +24,7 @@ export class Assets extends Resource {
     public async searchByAsset(
         payload: SearchAssetApiBody,
         query?: ApiQuery,
-    ): Promise<ApiResponseWithPagination<AssetsResource[]>> {
+    ): Promise<ApiResponseWithPagination<AssetsTimestamp[]>> {
         return this.sendPost("nft/assets/search", payload, query);
     }
 }

--- a/packages/nft-client/src/resources/base/burns.ts
+++ b/packages/nft-client/src/resources/base/burns.ts
@@ -1,9 +1,9 @@
 import { ApiResponse, ApiResponseWithPagination, Resource } from "@arkecosystem/client";
 
-import { AllBurnsQuery, Burns as BurnsResource } from "../../resourcesTypes/base";
+import { AllBurnsQuery, Burns as BurnsResource, BurnsTimestamp } from "../../resourcesTypes/base";
 
 export class Burns extends Resource {
-    public async all(query?: AllBurnsQuery): Promise<ApiResponseWithPagination<BurnsResource[]>> {
+    public async all(query?: AllBurnsQuery): Promise<ApiResponseWithPagination<BurnsTimestamp[]>> {
         return this.sendGet("nft/burns", query);
     }
 

--- a/packages/nft-client/src/resources/base/collections.ts
+++ b/packages/nft-client/src/resources/base/collections.ts
@@ -2,14 +2,16 @@ import { ApiResponse, ApiResponseWithPagination, Resource } from "@arkecosystem/
 
 import {
     AllCollectionsQuery,
-    Collections as CollectionsResource, CollectionsAsset,
+    Collections as CollectionsResource,
+    CollectionsTimestamp,
+    CollectionsAsset,
     CollectionsWallet,
     Schema,
     SearchCollectionsApiBody,
 } from "../../resourcesTypes/base/collections";
 
 export class Collections extends Resource {
-    public async all(query?: AllCollectionsQuery): Promise<ApiResponseWithPagination<CollectionsResource[]>> {
+    public async all(query?: AllCollectionsQuery): Promise<ApiResponseWithPagination<CollectionsTimestamp[]>> {
         return this.sendGet("nft/collections", query);
     }
 

--- a/packages/nft-client/src/resources/base/transfers.ts
+++ b/packages/nft-client/src/resources/base/transfers.ts
@@ -1,10 +1,10 @@
 import { ApiResponse, ApiResponseWithPagination, Resource } from "@arkecosystem/client";
 
-import { Transfers as TransfersResource } from "../../resourcesTypes/base";
+import { Transfers as TransfersResource, TransfersTimestamp } from "../../resourcesTypes/base";
 import { AllTransfersQuery } from "../../resourcesTypes/base";
 
 export class Transfers extends Resource {
-    public async all(query?: AllTransfersQuery): Promise<ApiResponseWithPagination<TransfersResource[]>>{
+    public async all(query?: AllTransfersQuery): Promise<ApiResponseWithPagination<TransfersTimestamp[]>> {
         return this.sendGet("nft/transfers");
     }
 

--- a/packages/nft-client/src/resources/exchange/auctions.ts
+++ b/packages/nft-client/src/resources/exchange/auctions.ts
@@ -4,14 +4,16 @@ import {
     AllAuctionCanceledQuery,
     AllAuctionsQuery,
     AuctionCanceled,
+    AuctionCanceledTimestamp,
     Auctions as AuctionsResource,
+    AuctionsTimestamp,
     AuctionsWallet,
     SearchAuctionsApiBody,
     SearchAuctionsApiQuery,
 } from "../../resourcesTypes/exchange";
 
 export class Auctions extends Resource {
-    public async getAllAuctions(query?: AllAuctionsQuery): Promise<ApiResponseWithPagination<AuctionsResource[]>> {
+    public async getAllAuctions(query?: AllAuctionsQuery): Promise<ApiResponseWithPagination<AuctionsTimestamp[]>> {
         return this.sendGet("nft/exchange/auctions");
     }
 
@@ -26,13 +28,13 @@ export class Auctions extends Resource {
     public async searchByAsset(
         payload: SearchAuctionsApiBody,
         query?: SearchAuctionsApiQuery,
-    ): Promise<ApiResponseWithPagination<AuctionsResource[]>> {
+    ): Promise<ApiResponseWithPagination<AuctionsTimestamp[]>> {
         return this.sendPost("nft/exchange/auctions/search", payload, query);
     }
 
     public async getAllCanceledAuctions(
         query?: AllAuctionCanceledQuery,
-    ): Promise<ApiResponseWithPagination<AuctionCanceled[]>> {
+    ): Promise<ApiResponseWithPagination<AuctionCanceledTimestamp[]>> {
         return this.sendGet("nft/exchange/auctions/canceled");
     }
 

--- a/packages/nft-client/src/resources/exchange/bids.ts
+++ b/packages/nft-client/src/resources/exchange/bids.ts
@@ -4,14 +4,16 @@ import {
     AllBidsCanceledQuery,
     AllBidsQuery,
     BidCanceled,
+    BidCanceledTimestamp,
     Bids as BidsResource,
+    BidsTimestamp,
     BidsWallet,
     SearchBidsApiBody,
     SearchBidsApiQuery,
 } from "../../resourcesTypes/exchange";
 
 export class Bids extends Resource {
-    public async getAllBids(query?: AllBidsQuery): Promise<ApiResponse<BidsResource>> {
+    public async getAllBids(query?: AllBidsQuery): Promise<ApiResponse<BidsTimestamp>> {
         return this.sendGet("nft/exchange/bids");
     }
 
@@ -26,11 +28,11 @@ export class Bids extends Resource {
     public async searchByBid(
         payload: SearchBidsApiBody,
         query?: SearchBidsApiQuery,
-    ): Promise<ApiResponseWithPagination<BidsResource[]>> {
+    ): Promise<ApiResponseWithPagination<BidsTimestamp[]>> {
         return this.sendPost("nft/exchange/bids/search", payload, query);
     }
 
-    public async getAllCanceledBids(query?: AllBidsCanceledQuery): Promise<ApiResponse<BidCanceled>> {
+    public async getAllCanceledBids(query?: AllBidsCanceledQuery): Promise<ApiResponse<BidCanceledTimestamp>> {
         return this.sendGet("nft/exchange/bids/canceled");
     }
     public async getCanceledBidById(id: string): Promise<ApiResponse<BidCanceled>> {

--- a/packages/nft-client/src/resourcesTypes/base/assets.ts
+++ b/packages/nft-client/src/resourcesTypes/base/assets.ts
@@ -8,6 +8,14 @@ export interface Assets {
     [attributes: string]: any;
 }
 
+export interface AssetsTimestamp extends Assets{
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
+    };
+}
+
 export interface AssetsWallet {
     address: string;
     publicKey: string;

--- a/packages/nft-client/src/resourcesTypes/base/burns.ts
+++ b/packages/nft-client/src/resourcesTypes/base/burns.ts
@@ -8,6 +8,14 @@ export interface Burns {
     };
 }
 
+export interface BurnsTimestamp extends Burns{
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
+    };
+}
+
 export interface AllBurnsQuery extends ApiQuery {
     orderBy?: string;
     transform?: boolean;

--- a/packages/nft-client/src/resourcesTypes/base/collections.ts
+++ b/packages/nft-client/src/resourcesTypes/base/collections.ts
@@ -10,6 +10,14 @@ export interface Collections {
     [jsonSchema: string]: any;
 }
 
+export interface CollectionsTimestamp extends Collections {
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
+    };
+}
+
 export interface AllCollectionsQuery extends ApiQuery {
     orderBy?: string;
     transform?: boolean;
@@ -51,5 +59,9 @@ export interface CollectionsAsset {
     collectionId: string;
     // eslint-disable-next-line @typescript-eslint/member-ordering
     [attributes: string]: any;
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
+    };
 }
-

--- a/packages/nft-client/src/resourcesTypes/base/transfers.ts
+++ b/packages/nft-client/src/resourcesTypes/base/transfers.ts
@@ -9,6 +9,14 @@ export interface Transfers {
     };
 }
 
+export interface TransfersTimestamp extends Transfers {
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
+    };
+}
+
 export interface AllTransfersQuery extends ApiQuery {
     orderBy?: string;
     transform?: boolean;

--- a/packages/nft-client/src/resourcesTypes/exchange/auctions.ts
+++ b/packages/nft-client/src/resourcesTypes/exchange/auctions.ts
@@ -12,6 +12,14 @@ export interface Auctions {
     };
 }
 
+export interface AuctionsTimestamp extends Auctions {
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
+    };
+}
+
 export interface AuctionsWallet {
     address: string;
     publicKey: string;
@@ -59,6 +67,14 @@ export interface AuctionCanceled {
     senderPublicKey: string;
     nftAuctionCanceled: {
         auctionId: string;
+    };
+}
+
+export interface AuctionCanceledTimestamp extends AuctionCanceled {
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
     };
 }
 

--- a/packages/nft-client/src/resourcesTypes/exchange/bids.ts
+++ b/packages/nft-client/src/resourcesTypes/exchange/bids.ts
@@ -9,6 +9,14 @@ export interface Bids {
     };
 }
 
+export interface BidsTimestamp extends Bids {
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
+    };
+}
+
 export interface AllBidsQuery extends ApiQuery {
     orderBy?: string;
     transform?: boolean;
@@ -53,6 +61,14 @@ export interface BidCanceled {
     senderPublicKey: string;
     nftBidCancel: {
         bidId: string;
+    };
+}
+
+export interface BidCanceledTimestamp extends BidCanceled {
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
     };
 }
 

--- a/packages/nft-client/src/resourcesTypes/exchange/trades.ts
+++ b/packages/nft-client/src/resourcesTypes/exchange/trades.ts
@@ -7,6 +7,11 @@ export interface Trades {
         auctionId: string;
         bidId: string;
     };
+    timestamp: {
+        epoch: number;
+        unix: number;
+        human: string;
+    };
 }
 
 export interface AllTradesQuery extends ApiQuery {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Added timestamp interface to some endpoints.

### Why are these changes necessary?
Making it possible to get timestamp from endpoints.

### How were these changes implemented? 
I added 
``` ts
timestamp: {
        epoch: number;
        unix: number;
        human: string;
    };
```
to some interfaces
OR
I added a new interface `interfaceName` + `Timestamp` added timestamp parameters and extended original interface since the original interface was still needed in some endpoints, so I didn't change it directly.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

