### PR TITLE
fix(nft-base-api + nft-exchange-api): add timestamp to single return endpoints

### DIFF
--- a/packages/nft-base-api/__tests__/unit/__support__/index.ts
+++ b/packages/nft-base-api/__tests__/unit/__support__/index.ts
@@ -40,6 +40,10 @@ export const transactionHistoryService = {
     listByCriteriaJoinBlock: jest.fn(),
 };
 
+export const blockHistoryService = {
+    findOneByCriteria: jest.fn(),
+};
+
 export const buildSenderWallet = (app: Application): Contracts.State.Wallet => {
     const walletRepository = app.get<Wallets.WalletRepository>(Identifiers.WalletRepository);
 
@@ -67,6 +71,7 @@ export const initApp = (): Application => {
     app.bind(Container.Identifiers.PeerStorage).toConstantValue({});
     app.bind(Container.Identifiers.TransactionPoolQuery).toConstantValue({});
     app.bind(Container.Identifiers.TransactionPoolProcessorFactory).toConstantValue({});
+    app.bind(Identifiers.BlockHistoryService).toConstantValue(blockHistoryService);
     app.bind(Container.Identifiers.TransactionHistoryService).toConstantValue(transactionHistoryService);
 
     app.bind(Identifiers.TransactionHandler).to(One.TransferTransactionHandler);

--- a/packages/nft-base-api/__tests__/unit/controllers/assets.test.ts
+++ b/packages/nft-base-api/__tests__/unit/controllers/assets.test.ts
@@ -12,7 +12,14 @@ import Hapi from "@hapi/hapi";
 import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { INFTTokens } from "@protokol/nft-base-transactions/src/interfaces";
 
-import { buildSenderWallet, initApp, ItemResponse, PaginatedResponse, transactionHistoryService } from "../__support__";
+import {
+    blockHistoryService,
+    buildSenderWallet,
+    initApp,
+    ItemResponse,
+    PaginatedResponse,
+    transactionHistoryService,
+} from "../__support__";
 import { AssetsController } from "../../../src/controllers/assets";
 
 let app: Application;
@@ -41,6 +48,8 @@ beforeEach(() => {
     transactionHistoryService.findOneByCriteria.mockReset();
     transactionHistoryService.listByCriteria.mockReset();
     transactionHistoryService.listByCriteriaJoinBlock.mockReset();
+
+    blockHistoryService.findOneByCriteria.mockReset();
 
     assetController = app.resolve<AssetsController>(AssetsController);
 
@@ -127,8 +136,12 @@ describe("Test asset controller", () => {
 
     it("show - return nftCreate transaction by its id", async () => {
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actual.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actual.id,
             },
@@ -147,6 +160,7 @@ describe("Test asset controller", () => {
                 health: 2,
                 mana: 2,
             },
+            timestamp,
         });
     });
 

--- a/packages/nft-base-api/__tests__/unit/controllers/burns.test.ts
+++ b/packages/nft-base-api/__tests__/unit/controllers/burns.test.ts
@@ -9,7 +9,13 @@ import { configManager } from "@arkecosystem/crypto/src/managers";
 import Hapi from "@hapi/hapi";
 import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 
-import { initApp, ItemResponse, PaginatedResponse, transactionHistoryService } from "../__support__";
+import {
+    blockHistoryService,
+    initApp,
+    ItemResponse,
+    PaginatedResponse,
+    transactionHistoryService,
+} from "../__support__";
 import { BurnsController } from "../../../src/controllers/burns";
 let app: Application;
 
@@ -30,6 +36,8 @@ beforeEach(() => {
     transactionHistoryService.findOneByCriteria.mockReset();
     transactionHistoryService.listByCriteria.mockReset();
     transactionHistoryService.listByCriteriaJoinBlock.mockReset();
+
+    blockHistoryService.findOneByCriteria.mockReset();
 
     burnsController = app.resolve<BurnsController>(BurnsController);
 
@@ -75,8 +83,12 @@ describe("Test burns controller", () => {
 
     it("show - return specific burn by its id", async () => {
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actual.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actual.id,
             },
@@ -89,6 +101,7 @@ describe("Test burns controller", () => {
             nftBurn: {
                 nftId: "8527a891e224136950ff32ca212b45bc93f69fbb801c3b1ebedac52775f99e61",
             },
+            timestamp,
         });
     });
 });

--- a/packages/nft-base-api/__tests__/unit/controllers/collections.test.ts
+++ b/packages/nft-base-api/__tests__/unit/controllers/collections.test.ts
@@ -12,7 +12,14 @@ import Hapi from "@hapi/hapi";
 import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { INFTCollections, INFTTokens } from "@protokol/nft-base-transactions/src/interfaces";
 
-import { buildSenderWallet, initApp, ItemResponse, PaginatedResponse, transactionHistoryService } from "../__support__";
+import {
+    blockHistoryService,
+    buildSenderWallet,
+    initApp,
+    ItemResponse,
+    PaginatedResponse,
+    transactionHistoryService,
+} from "../__support__";
 import { CollectionsController } from "../../../src/controllers/collections";
 
 let app: Application;
@@ -66,6 +73,8 @@ beforeEach(() => {
     transactionHistoryService.findOneByCriteria.mockReset();
     transactionHistoryService.listByCriteria.mockReset();
     transactionHistoryService.listByCriteriaJoinBlock.mockReset();
+
+    blockHistoryService.findOneByCriteria.mockReset();
 
     collectionController = app.resolve<CollectionsController>(CollectionsController);
 
@@ -162,8 +171,12 @@ describe("Test collection controller", () => {
 
     it("show - return specific collection transaction", async () => {
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actual.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actual.id,
             },
@@ -184,13 +197,18 @@ describe("Test collection controller", () => {
                     string: { type: "string" },
                 },
             },
+            timestamp,
         });
     });
 
     it("showSchema - return schema by specific id", async () => {
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actual.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actual.id,
             },
@@ -206,6 +224,7 @@ describe("Test collection controller", () => {
                 },
                 string: { type: "string" },
             },
+            timestamp,
         });
     });
 

--- a/packages/nft-base-api/__tests__/unit/controllers/transfers.test.ts
+++ b/packages/nft-base-api/__tests__/unit/controllers/transfers.test.ts
@@ -9,7 +9,13 @@ import { configManager } from "@arkecosystem/crypto/src/managers";
 import Hapi from "@hapi/hapi";
 import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 
-import { initApp, ItemResponse, PaginatedResponse, transactionHistoryService } from "../__support__";
+import {
+    blockHistoryService,
+    initApp,
+    ItemResponse,
+    PaginatedResponse,
+    transactionHistoryService,
+} from "../__support__";
 import { TransfersController } from "../../../src/controllers/transfers";
 let app: Application;
 
@@ -29,6 +35,8 @@ beforeEach(() => {
     transactionHistoryService.findManyByCriteria.mockReset();
     transactionHistoryService.findOneByCriteria.mockReset();
     transactionHistoryService.listByCriteria.mockReset();
+
+    blockHistoryService.findOneByCriteria.mockReset();
 
     transfersController = app.resolve<TransfersController>(TransfersController);
 
@@ -75,8 +83,12 @@ describe("Test transfer controller", () => {
 
     it("show - return specific transfer transaction by its id", async () => {
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actual.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actual.id,
             },
@@ -90,6 +102,7 @@ describe("Test transfer controller", () => {
                 nftIds: ["dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d"],
                 recipientId: Identities.Address.fromPassphrase(passphrases[1]),
             },
+            timestamp,
         });
     });
 });

--- a/packages/nft-base-api/src/controllers/assets.ts
+++ b/packages/nft-base-api/src/controllers/assets.ts
@@ -51,7 +51,7 @@ export class AssetsController extends BaseController {
         if (!transaction) {
             return Boom.notFound("Asset not found");
         }
-        return this.respondWithResource(transaction, AssetResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, AssetResource);
     }
 
     public async showByAsset(request: Hapi.Request, h: Hapi.ResponseToolkit) {

--- a/packages/nft-base-api/src/controllers/burns.ts
+++ b/packages/nft-base-api/src/controllers/burns.ts
@@ -34,6 +34,6 @@ export class BurnsController extends BaseController {
         if (!transaction) {
             return Boom.notFound("Burn Transaction not found");
         }
-        return this.respondWithResource(transaction, BurnsResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, BurnsResource);
     }
 }

--- a/packages/nft-base-api/src/controllers/collections.ts
+++ b/packages/nft-base-api/src/controllers/collections.ts
@@ -53,7 +53,7 @@ export class CollectionsController extends BaseController {
         if (!transaction) {
             return Boom.notFound("Collection not found");
         }
-        return this.respondWithResource(transaction, CollectionResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, CollectionResource);
     }
 
     public async showSchema(request: Hapi.Request, h: Hapi.ResponseToolkit) {
@@ -66,7 +66,7 @@ export class CollectionsController extends BaseController {
         if (!transaction) {
             return Boom.notFound("Collection not found");
         }
-        return this.respondWithResource(transaction, SchemaResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, SchemaResource);
     }
 
     public async searchCollection(request: Hapi.Request, h: Hapi.ResponseToolkit) {

--- a/packages/nft-base-api/src/controllers/transfers.ts
+++ b/packages/nft-base-api/src/controllers/transfers.ts
@@ -34,6 +34,6 @@ export class TransfersController extends BaseController {
         if (!transaction) {
             return Boom.notFound("NTF Transfer Transaction not found");
         }
-        return this.respondWithResource(transaction, TransferResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, TransferResource);
     }
 }

--- a/packages/nft-base-api/src/routes/assets.ts
+++ b/packages/nft-base-api/src/routes/assets.ts
@@ -33,6 +33,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.show,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),

--- a/packages/nft-base-api/src/routes/burns.ts
+++ b/packages/nft-base-api/src/routes/burns.ts
@@ -33,6 +33,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.show,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),

--- a/packages/nft-base-api/src/routes/collections.ts
+++ b/packages/nft-base-api/src/routes/collections.ts
@@ -33,6 +33,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.show,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),
@@ -46,6 +49,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.showSchema,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),

--- a/packages/nft-base-api/src/routes/transfers.ts
+++ b/packages/nft-base-api/src/routes/transfers.ts
@@ -33,6 +33,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.show,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),

--- a/packages/nft-exchange-api/__tests__/unit/__support__/index.ts
+++ b/packages/nft-exchange-api/__tests__/unit/__support__/index.ts
@@ -35,6 +35,10 @@ export const transactionHistoryService = {
     listByCriteriaJoinBlock: jest.fn(),
 };
 
+export const blockHistoryService = {
+    findOneByCriteria: jest.fn(),
+};
+
 export const buildSenderWallet = (app: Application): Contracts.State.Wallet => {
     const walletRepository = app.get<Wallets.WalletRepository>(Identifiers.WalletRepository);
 
@@ -66,6 +70,7 @@ export const initApp = (): Application => {
     transactionHistoryService.findOneByCriteria.mockReset();
     transactionHistoryService.listByCriteria.mockReset();
 
+    app.bind(Identifiers.BlockHistoryService).toConstantValue(blockHistoryService);
     app.bind(Identifiers.TransactionHistoryService).toConstantValue(transactionHistoryService);
 
     app.bind(Identifiers.TransactionHandler).to(One.TransferTransactionHandler);

--- a/packages/nft-exchange-api/__tests__/unit/controllers/auctions.test.ts
+++ b/packages/nft-exchange-api/__tests__/unit/controllers/auctions.test.ts
@@ -14,7 +14,7 @@ import { Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { Builders, Transactions as ExchangeTransactions } from "@protokol/nft-exchange-crypto";
 import { INFTAuctions } from "@protokol/nft-exchange-transactions/src/interfaces";
 
-import { initApp, transactionHistoryService } from "../__support__";
+import { blockHistoryService, initApp, transactionHistoryService } from "../__support__";
 import { AuctionsController } from "../../../src/controllers/auctions";
 
 let auctionsController: AuctionsController;
@@ -97,8 +97,12 @@ describe("Test auctions controller", () => {
 
     it("show - specific auction by its id ", async () => {
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actual.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actual.id,
             },
@@ -116,6 +120,7 @@ describe("Test auctions controller", () => {
                     blockHeight: 1,
                 },
             },
+            timestamp,
         });
     });
 
@@ -225,8 +230,12 @@ describe("Test auctions controller", () => {
             .sign(passphrases[0])
             .build();
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actualAuctionCanceled.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actualAuctionCanceled.id,
             },
@@ -239,6 +248,7 @@ describe("Test auctions controller", () => {
             nftAuctionCancel: {
                 auctionId: "dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d",
             },
+            timestamp,
         });
     });
 });

--- a/packages/nft-exchange-api/__tests__/unit/controllers/bids.test.ts
+++ b/packages/nft-exchange-api/__tests__/unit/controllers/bids.test.ts
@@ -13,7 +13,7 @@ import { buildSenderWallet, ItemResponse, PaginatedResponse } from "@protokol/nf
 import { Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { Builders, Transactions as ExchangeTransactions } from "@protokol/nft-exchange-crypto";
 
-import { initApp, transactionHistoryService } from "../__support__";
+import { blockHistoryService, initApp, transactionHistoryService } from "../__support__";
 import { INFTAuctions } from "../../../../nft-exchange-transactions/src/interfaces";
 import { BidsController } from "../../../src/controllers/bids";
 
@@ -93,8 +93,12 @@ describe("Test bids controller", () => {
 
     it("show - should return bid by its id ", async () => {
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actual.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actual.id,
             },
@@ -108,6 +112,7 @@ describe("Test bids controller", () => {
                 auctionId: "dfa8cbc8bba806348ebf112a4a01583ab869cccf72b72f7f3d28af9ff902d06d",
                 bidAmount: Utils.BigNumber.make("1"),
             },
+            timestamp,
         });
     });
 
@@ -217,8 +222,12 @@ describe("Test bids controller", () => {
             .build();
 
         transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actualCanceledBid.data);
+        blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
         const request: Hapi.Request = {
+            query: {
+                transform: true,
+            },
             params: {
                 id: actualCanceledBid.id,
             },
@@ -230,6 +239,7 @@ describe("Test bids controller", () => {
             nftBidCancel: {
                 bidId: "dab749f35c9c43c16f2a9a85b21e69551ae52a630a7fa73ef1d799931b108c2f",
             },
+            timestamp,
         });
     });
 });

--- a/packages/nft-exchange-api/__tests__/unit/controllers/trades.test.ts
+++ b/packages/nft-exchange-api/__tests__/unit/controllers/trades.test.ts
@@ -19,7 +19,7 @@ import {
 import { Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { Builders, Transactions as ExchangeTransactions } from "@protokol/nft-exchange-crypto";
 
-import { initApp, transactionHistoryService } from "../__support__";
+import { blockHistoryService, initApp, transactionHistoryService } from "../__support__";
 import { TradesController } from "../../../src/controllers/trades";
 
 let tradesController: TradesController;
@@ -130,8 +130,12 @@ describe("Test trades controller", () => {
                 .build();
             transactionHistoryService.findOneByCriteria.mockResolvedValueOnce(actual.data);
             transactionHistoryService.findManyByCriteria.mockResolvedValueOnce([auction.data, bid.data]);
+            blockHistoryService.findOneByCriteria.mockResolvedValueOnce({ timestamp: timestamp.epoch });
 
             const request: Hapi.Request = {
+                query: {
+                    transform: true,
+                },
                 params: {
                     id: actual.id,
                 },
@@ -152,6 +156,7 @@ describe("Test trades controller", () => {
                         ...bid.data.asset!.nftBid,
                     },
                 },
+                timestamp,
             });
         });
     });

--- a/packages/nft-exchange-api/src/controllers/auctions.ts
+++ b/packages/nft-exchange-api/src/controllers/auctions.ts
@@ -41,7 +41,7 @@ export class AuctionsController extends BaseController {
         if (!transaction) {
             return Boom.notFound("Auction not found");
         }
-        return this.respondWithResource(transaction, AuctionResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, AuctionResource);
     }
 
     public async showAuctionWallet(request: Hapi.Request, h: Hapi.ResponseToolkit) {
@@ -133,6 +133,6 @@ export class AuctionsController extends BaseController {
         if (!transaction) {
             return Boom.notFound("Auction not found");
         }
-        return this.respondWithResource(transaction, AuctionCancelResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, AuctionCancelResource);
     }
 }

--- a/packages/nft-exchange-api/src/controllers/base-controller.ts
+++ b/packages/nft-exchange-api/src/controllers/base-controller.ts
@@ -1,5 +1,6 @@
 import { Controller } from "@arkecosystem/core-api";
 import { Container, Contracts } from "@arkecosystem/core-kernel";
+import { Interfaces } from "@arkecosystem/crypto";
 
 import { ResourceWithBlock } from "../resources/resource-with-block";
 
@@ -7,6 +8,9 @@ import { ResourceWithBlock } from "../resources/resource-with-block";
 export class BaseController extends Controller {
     @Container.inject(Container.Identifiers.TransactionHistoryService)
     protected readonly transactionHistoryService!: Contracts.Shared.TransactionHistoryService;
+
+    @Container.inject(Container.Identifiers.BlockHistoryService)
+    private readonly blockHistoryService!: Contracts.Shared.BlockHistoryService;
 
     public async paginateWithBlock(
         criteria: Contracts.Shared.TransactionCriteria | Contracts.Shared.TransactionCriteria[],
@@ -25,6 +29,24 @@ export class BaseController extends Controller {
         } else {
             const transactionListResult = await this.transactionHistoryService.listByCriteria(criteria, order, page);
             return this.toPagination(transactionListResult, resource, false);
+        }
+    }
+
+    public async respondWithBlockResource(
+        transaction: Interfaces.ITransactionData,
+        transform: boolean,
+        resource,
+        data?,
+    ) {
+        if (transform) {
+            const blockData = await this.blockHistoryService.findOneByCriteria({ id: transaction.blockId });
+            return this.respondWithResource(
+                { data: data || transaction, block: blockData },
+                ResourceWithBlock(resource),
+                true,
+            );
+        } else {
+            return this.respondWithResource(transaction, resource, false);
         }
     }
 }

--- a/packages/nft-exchange-api/src/controllers/bids.ts
+++ b/packages/nft-exchange-api/src/controllers/bids.ts
@@ -41,7 +41,7 @@ export class BidsController extends BaseController {
         if (!transaction) {
             return Boom.notFound("Bid not found");
         }
-        return this.respondWithResource(transaction, BidResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, BidResource);
     }
 
     public async showAuctionWallet(request: Hapi.Request, h: Hapi.ResponseToolkit) {
@@ -122,6 +122,6 @@ export class BidsController extends BaseController {
         if (!transaction) {
             return Boom.notFound("Auction not found");
         }
-        return this.respondWithResource(transaction, BidCancelResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, BidCancelResource);
     }
 }

--- a/packages/nft-exchange-api/src/controllers/trades.ts
+++ b/packages/nft-exchange-api/src/controllers/trades.ts
@@ -50,7 +50,7 @@ export class TradesController extends BaseController {
             bid: transactions.find((tx) => tx.id === nftAcceptTrade.bidId),
         };
 
-        return this.respondWithResource(result, TradeDetailsResource);
+        return this.respondWithBlockResource(transaction, request.query.transform, TradeDetailsResource, result);
     }
 
     public async search(request: Hapi.Request, h: Hapi.ResponseToolkit) {

--- a/packages/nft-exchange-api/src/routes/auctions.ts
+++ b/packages/nft-exchange-api/src/routes/auctions.ts
@@ -33,6 +33,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.show,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),
@@ -107,6 +110,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.showAuctionCanceled,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),

--- a/packages/nft-exchange-api/src/routes/bids.ts
+++ b/packages/nft-exchange-api/src/routes/bids.ts
@@ -33,6 +33,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.show,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),
@@ -104,6 +107,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.showAuctionCanceled,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),

--- a/packages/nft-exchange-api/src/routes/trades.ts
+++ b/packages/nft-exchange-api/src/routes/trades.ts
@@ -33,6 +33,9 @@ export const register = (server: Hapi.Server): void => {
         handler: controller.show,
         options: {
             validate: {
+                query: Joi.object({
+                    transform: Joi.bool().default(true),
+                }),
                 params: Joi.object({
                     id: Joi.string().hex().length(64),
                 }),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Timestamp object is added to every API endpoint response that fetches a transaction before only pagination responses included a timestamp object. Partially solve #110, still need documentation updates -> next thing to do after merge.

### Why are these changes necessary?
All endpoints include a timestamp of the transaction to give us the option to sort by in frontend.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

