### PR TITLE
refactor: remove core-kernel as deps

### DIFF
--- a/packages/nft-base-crypto/package.json
+++ b/packages/nft-base-crypto/package.json
@@ -40,11 +40,11 @@
         "test:unit:coverage": "cross-env jest __tests__/unit --coverage"
     },
     "dependencies": {
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@types/prettier": "^2.0.0",
         "@types/rimraf": "^3.0.0",
         "@types/uuid": "^7.0.2",

--- a/packages/nft-base-crypto/package.json
+++ b/packages/nft-base-crypto/package.json
@@ -44,7 +44,6 @@
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@types/prettier": "^2.0.0",
         "@types/rimraf": "^3.0.0",
         "@types/uuid": "^7.0.2",

--- a/packages/nft-base-crypto/src/exceptions/base.ts
+++ b/packages/nft-base-crypto/src/exceptions/base.ts
@@ -1,0 +1,29 @@
+/**
+ * @export
+ * @class Exception
+ * @extends {Error}
+ */
+export class Exception extends Error {
+    /**
+     * Creates an instance of Exception.
+     *
+     * @param {string} message
+     * @param {string} [code]
+     * @memberof Exception
+     */
+    public constructor(message: string, code?: string) {
+        super(message);
+
+        Object.defineProperty(this, "message", {
+            enumerable: false,
+            value: code ? `${code}: ${message}` : message,
+        });
+
+        Object.defineProperty(this, "name", {
+            enumerable: false,
+            value: this.constructor.name,
+        });
+
+        Error.captureStackTrace(this, this.constructor);
+    }
+}

--- a/packages/nft-base-crypto/src/exceptions/index.ts
+++ b/packages/nft-base-crypto/src/exceptions/index.ts
@@ -1,0 +1,2 @@
+export * from "./base";
+export * from "./runtime";

--- a/packages/nft-base-crypto/src/exceptions/runtime.ts
+++ b/packages/nft-base-crypto/src/exceptions/runtime.ts
@@ -1,0 +1,15 @@
+import { Exception } from "./base";
+
+/**
+ * @export
+ * @class RuntimeException
+ * @extends {Exception}
+ */
+export class RuntimeException extends Exception {}
+
+/**
+ * @export
+ * @class AssertionException
+ * @extends {Exception}
+ */
+export class AssertionException extends RuntimeException {}

--- a/packages/nft-base-crypto/src/transactions/nft-burn.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-burn.ts
@@ -1,9 +1,9 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 
 import { NFTBaseStaticFees, NFTBaseTransactionGroup, NFTBaseTransactionTypes } from "../enums";
 import { NFTBurnAsset } from "../interfaces";
+import { assert } from "../utils";
 
 const { schemas } = Transactions;
 
@@ -46,7 +46,7 @@ export class NFTBurnTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        AppUtils.assert.defined<NFTBurnAsset>(data.asset?.nftBurn);
+        assert.defined<NFTBurnAsset>(data.asset?.nftBurn);
         const nftBurnAsset: NFTBurnAsset = data.asset.nftBurn;
 
         const buffer: ByteBuffer = new ByteBuffer(32, true);

--- a/packages/nft-base-crypto/src/transactions/nft-create.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-create.ts
@@ -1,10 +1,10 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Transactions, Utils, Validation } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 
 import { defaults } from "../defaults";
 import { NFTBaseStaticFees, NFTBaseTransactionGroup, NFTBaseTransactionTypes } from "../enums";
 import { NFTTokenAsset } from "../interfaces";
+import { assert } from "../utils";
 
 const { schemas } = Transactions;
 
@@ -64,7 +64,7 @@ export class NFTCreateTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        AppUtils.assert.defined<NFTTokenAsset>(data.asset?.nftToken);
+        assert.defined<NFTTokenAsset>(data.asset?.nftToken);
         const nftToken: NFTTokenAsset = data.asset.nftToken;
 
         const dataBuffer = Buffer.from(JSON.stringify(nftToken.attributes));

--- a/packages/nft-base-crypto/src/transactions/nft-register-collection.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-register-collection.ts
@@ -1,10 +1,10 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Transactions, Utils, Validation } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 
 import { defaults } from "../defaults";
 import { NFTBaseStaticFees, NFTBaseTransactionGroup, NFTBaseTransactionTypes } from "../enums";
 import { NFTCollectionAsset } from "../interfaces";
+import { assert } from "../utils";
 
 const { schemas } = Transactions;
 
@@ -91,7 +91,7 @@ export class NFTRegisterCollectionTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        AppUtils.assert.defined<NFTCollectionAsset>(data.asset?.nftCollection);
+        assert.defined<NFTCollectionAsset>(data.asset?.nftCollection);
         const nftCollectionAsset: NFTCollectionAsset = data.asset.nftCollection;
 
         const nameBuffer: Buffer = Buffer.from(nftCollectionAsset.name, "utf8");

--- a/packages/nft-base-crypto/src/transactions/nft-transfer.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-transfer.ts
@@ -1,4 +1,3 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import { Identities } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
@@ -6,6 +5,7 @@ import ByteBuffer from "bytebuffer";
 import { defaults } from "../defaults";
 import { NFTBaseStaticFees, NFTBaseTransactionGroup, NFTBaseTransactionTypes } from "../enums";
 import { NFTTransferAsset } from "../interfaces";
+import { assert } from "../utils";
 
 const { schemas } = Transactions;
 
@@ -56,7 +56,7 @@ export class NFTTransferTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        AppUtils.assert.defined<NFTTransferAsset>(data.asset?.nftTransfer);
+        assert.defined<NFTTransferAsset>(data.asset?.nftTransfer);
         const nftTransfer: NFTTransferAsset = data.asset.nftTransfer;
 
         const buffer: ByteBuffer = new ByteBuffer(1 + 32 * nftTransfer.nftIds.length + 21, true);

--- a/packages/nft-base-crypto/src/utils/assert.ts
+++ b/packages/nft-base-crypto/src/utils/assert.ts
@@ -1,0 +1,67 @@
+import { Blocks, Transactions } from "@arkecosystem/crypto";
+
+import { AssertionException } from "../exceptions";
+
+const assertType = (condition: boolean, description: string): asserts condition => {
+    if (!condition) {
+        throw new AssertionException(`Expected value which is "${description}".`);
+    }
+};
+
+interface Assert {
+    boolean: (value: unknown) => asserts value is boolean;
+    buffer: (value: unknown) => asserts value is Buffer;
+    number: (value: unknown) => asserts value is number;
+    object: (value: unknown) => asserts value is Record<string, any>;
+    string: (value: unknown) => asserts value is string;
+    symbol: (value: unknown) => asserts value is symbol;
+    undefined: (value: unknown) => asserts value is undefined;
+
+    array: <T>(value: unknown) => asserts value is Array<T>;
+    bigint: (value: unknown) => asserts value is bigint;
+    block(value: unknown): asserts value is Blocks.Block;
+    defined<T>(value: unknown): asserts value is NonNullable<T>;
+    transaction(value: unknown): asserts value is Transactions.Transaction;
+}
+
+/**
+ * Type assertions have to be declared with an explicit type.
+ */
+export const assert: Assert = {
+    array: <T>(value: unknown): asserts value is Array<T> => {
+        return assertType(Array.isArray(value), "array");
+    },
+    bigint: (value: unknown): asserts value is bigint => {
+        return assertType(typeof value === "bigint", "bigint");
+    },
+    block: (value: unknown): asserts value is Blocks.Block => {
+        return assertType(value instanceof Blocks.Block, "Crypto.Blocks.Block");
+    },
+    boolean: (value: unknown): asserts value is boolean => {
+        return assertType(typeof value === "boolean", "boolean");
+    },
+    buffer: (value: unknown): asserts value is Buffer => {
+        return assertType(value instanceof Buffer, "buffer");
+    },
+    defined: <T>(value: unknown): asserts value is NonNullable<T> => {
+        return assertType(value !== undefined && value !== null, "non-null and non-undefined");
+    },
+    number: (value: unknown): asserts value is number => {
+        return assertType(typeof value === "number", "number");
+    },
+    object: (value: unknown): asserts value is Record<string, any> => {
+        return assertType(typeof value === "object", "object");
+    },
+    string: (value: unknown): asserts value is string => {
+        return assertType(typeof value === "string", "string");
+    },
+    symbol: (value: unknown): asserts value is symbol => {
+        return assertType(typeof value === "symbol", "symbol");
+    },
+    transaction: (value: unknown): asserts value is Transactions.Transaction => {
+        return assertType(value instanceof Transactions.Transaction, "Crypto.Transactions.Transaction");
+    },
+    undefined: (value: unknown): asserts value is undefined => {
+        return assertType(typeof value === "undefined", "undefined");
+    },
+};

--- a/packages/nft-base-crypto/src/utils/index.ts
+++ b/packages/nft-base-crypto/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./assert";


### PR DESCRIPTION
## Summary

Remove `@arkecosystem/core-kernel`, the `pm2/io` package breaks an Electron app.

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

