### PR TITLE
refactor: core-kernel utils imports

### DIFF
--- a/packages/nft-base-crypto/src/transactions/nft-burn.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-burn.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 

--- a/packages/nft-base-crypto/src/transactions/nft-create.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-create.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils, Validation } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 

--- a/packages/nft-base-crypto/src/transactions/nft-register-collection.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-register-collection.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils, Validation } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 

--- a/packages/nft-base-crypto/src/transactions/nft-transfer.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-transfer.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import { Identities } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";

--- a/packages/nft-exchange-crypto/src/transactions/nft-accept-trade.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-accept-trade.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 

--- a/packages/nft-exchange-crypto/src/transactions/nft-auction-cancel.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-auction-cancel.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 

--- a/packages/nft-exchange-crypto/src/transactions/nft-auction.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-auction.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 

--- a/packages/nft-exchange-crypto/src/transactions/nft-bid-cancel.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-bid-cancel.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 

--- a/packages/nft-exchange-crypto/src/transactions/nft-bid.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-bid.ts
@@ -1,4 +1,4 @@
-import { Utils as AppUtils } from "@arkecosystem/core-kernel";
+import * as AppUtils from "@arkecosystem/core-kernel/dist/utils";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
 


### PR DESCRIPTION
## Summary

Remove @arkecosystem/core-kernel, the pm2/io package breaks an Electron app.

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
