### PR TITLE
feat: use protokol utils

### DIFF
--- a/packages/nft-base-crypto/package.json
+++ b/packages/nft-base-crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-base-crypto",
-    "version": "1.0.0-beta.10",
+    "version": "1.0.0-beta.11",
     "description": "Transaction Builders For Base NFT Transaction Types",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -40,11 +40,12 @@
         "test:unit:coverage": "cross-env jest __tests__/unit --coverage"
     },
     "dependencies": {
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
+        "@protokol/utils": "^1.0.0-beta.0",
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@types/prettier": "^2.0.0",
         "@types/rimraf": "^3.0.0",
         "@types/uuid": "^7.0.2",

--- a/packages/nft-base-crypto/src/transactions/nft-burn.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-burn.ts
@@ -1,5 +1,5 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { NFTBaseStaticFees, NFTBaseTransactionGroup, NFTBaseTransactionTypes } from "../enums";
@@ -46,7 +46,7 @@ export class NFTBurnTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTBurnAsset>(data.asset?.nftBurn);
+        Asserts.assert.defined<NFTBurnAsset>(data.asset?.nftBurn);
         const nftBurnAsset: NFTBurnAsset = data.asset.nftBurn;
 
         const buffer: ByteBuffer = new ByteBuffer(32, true);

--- a/packages/nft-base-crypto/src/transactions/nft-create.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-create.ts
@@ -1,5 +1,5 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils, Validation } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { defaults } from "../defaults";
@@ -64,7 +64,7 @@ export class NFTCreateTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTTokenAsset>(data.asset?.nftToken);
+        Asserts.assert.defined<NFTTokenAsset>(data.asset?.nftToken);
         const nftToken: NFTTokenAsset = data.asset.nftToken;
 
         const dataBuffer = Buffer.from(JSON.stringify(nftToken.attributes));

--- a/packages/nft-base-crypto/src/transactions/nft-register-collection.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-register-collection.ts
@@ -1,5 +1,5 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils, Validation } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { defaults } from "../defaults";
@@ -91,7 +91,7 @@ export class NFTRegisterCollectionTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTCollectionAsset>(data.asset?.nftCollection);
+        Asserts.assert.defined<NFTCollectionAsset>(data.asset?.nftCollection);
         const nftCollectionAsset: NFTCollectionAsset = data.asset.nftCollection;
 
         const nameBuffer: Buffer = Buffer.from(nftCollectionAsset.name, "utf8");

--- a/packages/nft-base-crypto/src/transactions/nft-transfer.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-transfer.ts
@@ -1,6 +1,6 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import { Identities } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { defaults } from "../defaults";
@@ -56,7 +56,7 @@ export class NFTTransferTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTTransferAsset>(data.asset?.nftTransfer);
+        Asserts.assert.defined<NFTTransferAsset>(data.asset?.nftTransfer);
         const nftTransfer: NFTTransferAsset = data.asset.nftTransfer;
 
         const buffer: ByteBuffer = new ByteBuffer(1 + 32 * nftTransfer.nftIds.length + 21, true);

--- a/packages/nft-examples/package.json
+++ b/packages/nft-examples/package.json
@@ -39,8 +39,8 @@
 	"dependencies": {
         "@protokol/nft-client": "^1.0.0-beta.8",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.10",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.10"
+        "@protokol/nft-base-crypto": "^1.0.0-beta.11",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.11"
     },
 	"devDependencies": {
 		"@types/prettier": "^2.0.0",

--- a/packages/nft-exchange-crypto/package.json
+++ b/packages/nft-exchange-crypto/package.json
@@ -41,6 +41,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
+        "@protokol/utils": "^1.0.0-beta.0",
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {

--- a/packages/nft-exchange-crypto/package.json
+++ b/packages/nft-exchange-crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-exchange-crypto",
-    "version": "1.0.0-beta.10",
+    "version": "1.0.0-beta.11",
     "description": "Transaction Builders For Exchange NFT Transaction Types",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -40,9 +40,11 @@
         "test:unit:coverage": "cross-env jest __tests__/unit --coverage"
     },
     "dependencies": {
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
         "bytebuffer": "^5.0.1"
+    },
+    "devDependencies": {
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/nft-exchange-crypto/src/transactions/nft-accept-trade.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-accept-trade.ts
@@ -1,5 +1,5 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { NFTExchangeTransactionsTypeGroup, NFTStaticFees, NFTTransactionTypes } from "../enums";
@@ -47,7 +47,7 @@ export class NFTAcceptTradeTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTAcceptTradeAsset>(data.asset?.nftAcceptTrade);
+        Asserts.assert.defined<NFTAcceptTradeAsset>(data.asset?.nftAcceptTrade);
 
         const buffer: ByteBuffer = new ByteBuffer(32 + 32, true);
 

--- a/packages/nft-exchange-crypto/src/transactions/nft-auction-cancel.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-auction-cancel.ts
@@ -1,5 +1,5 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { NFTExchangeTransactionsTypeGroup, NFTStaticFees, NFTTransactionTypes } from "../enums";
@@ -44,7 +44,7 @@ export class NFTAuctionCancelTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTAuctionCancel>(data.asset?.nftAuctionCancel);
+        Asserts.assert.defined<NFTAuctionCancel>(data.asset?.nftAuctionCancel);
 
         const buffer: ByteBuffer = new ByteBuffer(32, true);
 

--- a/packages/nft-exchange-crypto/src/transactions/nft-auction.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-auction.ts
@@ -1,5 +1,5 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { defaults } from "../defaults";
@@ -64,7 +64,7 @@ export class NFTAuctionTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTAuctionAsset>(data.asset?.nftAuction);
+        Asserts.assert.defined<NFTAuctionAsset>(data.asset?.nftAuction);
         const nftAuctionAsset = data.asset.nftAuction;
 
         const buffer: ByteBuffer = new ByteBuffer(32 * nftAuctionAsset.nftIds.length + 8 + 8, true);

--- a/packages/nft-exchange-crypto/src/transactions/nft-bid-cancel.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-bid-cancel.ts
@@ -1,5 +1,5 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { NFTExchangeTransactionsTypeGroup, NFTStaticFees, NFTTransactionTypes } from "../enums";
@@ -44,7 +44,7 @@ export class NFTBidCancelTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTBidCancelAsset>(data.asset?.nftBidCancel);
+        Asserts.assert.defined<NFTBidCancelAsset>(data.asset?.nftBidCancel);
 
         const buffer: ByteBuffer = new ByteBuffer(32, true);
 

--- a/packages/nft-exchange-crypto/src/transactions/nft-bid.ts
+++ b/packages/nft-exchange-crypto/src/transactions/nft-bid.ts
@@ -1,5 +1,5 @@
-import { assert } from "@arkecosystem/core-kernel/dist/utils/assert";
 import { Transactions, Utils } from "@arkecosystem/crypto";
+import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 
 import { NFTExchangeTransactionsTypeGroup, NFTStaticFees, NFTTransactionTypes } from "../enums";
@@ -47,7 +47,7 @@ export class NFTBidTransaction extends Transactions.Transaction {
     public serialize(): ByteBuffer {
         const { data } = this;
 
-        assert.defined<NFTBidAsset>(data.asset?.nftBid);
+        Asserts.assert.defined<NFTBidAsset>(data.asset?.nftBid);
 
         const buffer: ByteBuffer = new ByteBuffer(32 + 8, true);
 

--- a/packages/nft-exchange-transactions/package.json
+++ b/packages/nft-exchange-transactions/package.json
@@ -47,8 +47,8 @@
         "@arkecosystem/core-state": "^3.0.0-alpha.0",
         "@arkecosystem/core-transactions": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.10",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.10",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.11",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.11",
         "@protokol/nft-base-transactions": "^1.0.0-beta.8"
     },
     "publishConfig": {

--- a/packages/nft-generator-api/package.json
+++ b/packages/nft-generator-api/package.json
@@ -43,9 +43,9 @@
         "@hapi/boom": "^9.0.0",
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.8",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.11",
         "@protokol/nft-base-transactions": "^1.0.0-beta.8",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.8",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.11",
         "@protokol/nft-exchange-transactions": "^1.0.0-beta.8",
         "got": "^11.0.3"
     },

--- a/packages/nft-tx-tester/package.json
+++ b/packages/nft-tx-tester/package.json
@@ -52,8 +52,8 @@
         "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
         "fs-extra": "^9.0.1",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.10",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.10",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.11",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.11",
         "@oclif/command": "^1",
         "@oclif/plugin-help": "^3"
     },


### PR DESCRIPTION
## Summary

- use `@protokol/utils` instead of `@arkecosystem/core-kernel` for asserts;
- bump version for cryto packages release;

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged
