### PR TITLE
refactor: expose ark crypto

### DIFF
--- a/packages/nft-base-crypto/package.json
+++ b/packages/nft-base-crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-base-crypto",
-    "version": "1.0.0-beta.11",
+    "version": "1.0.0-beta.12",
     "description": "Transaction Builders For Base NFT Transaction Types",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",

--- a/packages/nft-base-crypto/src/index.ts
+++ b/packages/nft-base-crypto/src/index.ts
@@ -1,4 +1,9 @@
-import * as ArkCrypto from "@arkecosystem/crypto";
+import {
+    Identities as ArkIdentities,
+    Managers as ArkManagers,
+    Transactions as ArkTransactions,
+    Utils as ArkUtils,
+} from "@arkecosystem/crypto";
 
 import * as Builders from "./builders";
 import * as Defaults from "./defaults";
@@ -6,4 +11,4 @@ import * as Enums from "./enums";
 import * as Interfaces from "./interfaces";
 import * as Transactions from "./transactions";
 
-export { ArkCrypto, Builders, Transactions, Interfaces, Enums, Defaults };
+export { ArkIdentities, ArkManagers, ArkTransactions, ArkUtils, Builders, Transactions, Interfaces, Enums, Defaults };

--- a/packages/nft-base-crypto/src/index.ts
+++ b/packages/nft-base-crypto/src/index.ts
@@ -1,7 +1,9 @@
+import * as ArkCrypto from "@arkecosystem/crypto";
+
 import * as Builders from "./builders";
 import * as Defaults from "./defaults";
 import * as Enums from "./enums";
 import * as Interfaces from "./interfaces";
 import * as Transactions from "./transactions";
 
-export { Builders, Transactions, Interfaces, Enums, Defaults };
+export { ArkCrypto, Builders, Transactions, Interfaces, Enums, Defaults };

--- a/packages/nft-exchange-crypto/package.json
+++ b/packages/nft-exchange-crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-exchange-crypto",
-    "version": "1.0.0-beta.11",
+    "version": "1.0.0-beta.12",
     "description": "Transaction Builders For Exchange NFT Transaction Types",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",

--- a/packages/nft-exchange-crypto/src/index.ts
+++ b/packages/nft-exchange-crypto/src/index.ts
@@ -1,4 +1,9 @@
-import * as ArkCrypto from "@arkecosystem/crypto";
+import {
+    Identities as ArkIdentities,
+    Managers as ArkManagers,
+    Transactions as ArkTransactions,
+    Utils as ArkUtils,
+} from "@arkecosystem/crypto";
 
 import * as Builders from "./builders";
 import * as Defaults from "./defaults";
@@ -6,4 +11,4 @@ import * as Enums from "./enums";
 import * as Interfaces from "./interfaces";
 import * as Transactions from "./transactions";
 
-export { ArkCrypto, Builders, Transactions, Interfaces, Enums, Defaults };
+export { ArkIdentities, ArkManagers, ArkTransactions, ArkUtils, Builders, Transactions, Interfaces, Enums, Defaults };

--- a/packages/nft-exchange-crypto/src/index.ts
+++ b/packages/nft-exchange-crypto/src/index.ts
@@ -1,7 +1,9 @@
+import * as ArkCrypto from "@arkecosystem/crypto";
+
 import * as Builders from "./builders";
 import * as Defaults from "./defaults";
 import * as Enums from "./enums";
 import * as Interfaces from "./interfaces";
 import * as Transactions from "./transactions";
 
-export { Builders, Transactions, Interfaces, Enums, Defaults };
+export { ArkCrypto, Builders, Transactions, Interfaces, Enums, Defaults };


### PR DESCRIPTION
## Summary

Expose `@arkecosystem/crypto` package, since for some reason Electron create new instance when importing the same package, and we can't set config on configManager, becase the instance differentiate.

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged
