### PR TITLE
feat(all): sync with latest ark core develop and version bump for all to beta.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "nft-core",
-    "version": "1.0.0-beta.8",
+    "version": "1.0.0-beta.21",
     "description": "NFT Functionality For Any ARK Core-v3 Bridgechain",
     "engineStrict": true,
     "scripts": {

--- a/packages/nft-base-api/README.md
+++ b/packages/nft-base-api/README.md
@@ -6,6 +6,7 @@
 A Protokol module providing NFT Transaction support for the ARK Core Blockchain Framework.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-base-api/__tests__/integration/handlers/configurations.test.ts
+++ b/packages/nft-base-api/__tests__/integration/handlers/configurations.test.ts
@@ -2,9 +2,9 @@ import "@arkecosystem/core-test-framework/src/matchers";
 
 import { Contracts } from "@arkecosystem/core-kernel";
 import { ApiHelpers } from "@arkecosystem/core-test-framework/src";
+import latestVersion from "latest-version";
 
 import { setUp, tearDown } from "../__support__/setup";
-import latestVersion from "latest-version";
 
 let app: Contracts.Kernel.Application;
 let api: ApiHelpers;

--- a/packages/nft-base-api/package.json
+++ b/packages/nft-base-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-base-api",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "description": "REST API For Base NFT Functionality",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -47,8 +47,8 @@
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",
         "latest-version": "^5.1.0",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
-        "@protokol/nft-base-transactions": "^1.0.0-beta.20"
+        "@protokol/nft-base-crypto": "^1.0.0-beta.21",
+        "@protokol/nft-base-transactions": "^1.0.0-beta.21"
     },
     "devDependencies": {
         "@types/hapi__boom": "^7.4.1",

--- a/packages/nft-base-api/package.json
+++ b/packages/nft-base-api/package.json
@@ -41,8 +41,8 @@
         "test:integration:coverage": "cross-env CORE_ENV=test jest __tests__/integration --coverage --runInBand --forceExit"
     },
     "dependencies": {
-        "@arkecosystem/core-api": "^3.0.0-alpha.0",
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
+        "@arkecosystem/core-api": "^3.0.0-alpha.1",
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.1",
         "@hapi/boom": "^9.0.0",
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",

--- a/packages/nft-base-api/package.json
+++ b/packages/nft-base-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-base-api",
-    "version": "1.0.0-beta.8",
+    "version": "1.0.0-beta.20",
     "description": "REST API For Base NFT Functionality",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -47,8 +47,8 @@
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",
         "latest-version": "^5.1.0",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.13",
-        "@protokol/nft-base-transactions": "^1.0.0-beta.8"
+        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
+        "@protokol/nft-base-transactions": "^1.0.0-beta.20"
     },
     "devDependencies": {
         "@types/hapi__boom": "^7.4.1",

--- a/packages/nft-base-crypto/README.md
+++ b/packages/nft-base-crypto/README.md
@@ -2,9 +2,11 @@
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 # NFT-BASE-CRYPTO
+
 A Protokol module providing NFT CRYPTO support for the ARK Core Blockchain Framework.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-base-crypto/__tests__/unit/builders/nft-create.test.ts
+++ b/packages/nft-base-crypto/__tests__/unit/builders/nft-create.test.ts
@@ -3,8 +3,8 @@ import "jest-extended";
 import { Managers, Transactions } from "@arkecosystem/crypto";
 
 import { NFTCreateBuilder } from "../../../src/builders";
-import { NFTCreateTransaction } from "../../../src/transactions";
 import { defaults } from "../../../src/defaults";
+import { NFTCreateTransaction } from "../../../src/transactions";
 
 describe("NFT Create tests ", () => {
     describe("Verify tests", () => {

--- a/packages/nft-base-crypto/package.json
+++ b/packages/nft-base-crypto/package.json
@@ -46,17 +46,17 @@
         "test:unit:coverage": "cross-env jest __tests__/unit --coverage"
     },
     "dependencies": {
-        "@arkecosystem/crypto": "^3.0.0-alpha.0",
+        "@arkecosystem/crypto": "^3.0.0-alpha.1",
         "@protokol/utils": "^1.0.0-beta.20",
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.1",
         "@rollup/plugin-babel": "^5.0.4",
         "@rollup/plugin-commonjs": "^13.0.0",
         "@rollup/plugin-inject": "^4.0.2",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^8.1.0",
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@types/prettier": "^2.0.0",
         "@types/rimraf": "^3.0.0",
         "@types/uuid": "^7.0.2",

--- a/packages/nft-base-crypto/package.json
+++ b/packages/nft-base-crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-base-crypto",
-    "version": "1.0.0-beta.13",
+    "version": "1.0.0-beta.20",
     "description": "Transaction Builders For Base NFT Transaction Types",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -47,7 +47,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@protokol/utils": "^1.0.0-beta.3",
+        "@protokol/utils": "^1.0.0-beta.20",
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {

--- a/packages/nft-base-crypto/package.json
+++ b/packages/nft-base-crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-base-crypto",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "description": "Transaction Builders For Base NFT Transaction Types",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -47,7 +47,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto": "^3.0.0-alpha.1",
-        "@protokol/utils": "^1.0.0-beta.20",
+        "@protokol/utils": "^1.0.0-beta.21",
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {

--- a/packages/nft-base-crypto/rollup.config.js
+++ b/packages/nft-base-crypto/rollup.config.js
@@ -60,9 +60,7 @@ const browserConfig = {
         {
             file: pkg.unpkg,
             format: "esm",
-            plugins: [
-                terser(),
-            ]
+            plugins: [terser()],
         },
         {
             file: pkg.browser,

--- a/packages/nft-base-crypto/src/transactions/nft-transfer.ts
+++ b/packages/nft-base-crypto/src/transactions/nft-transfer.ts
@@ -1,4 +1,4 @@
-import { Transactions, Utils, Identities } from "@arkecosystem/crypto";
+import { Identities, Transactions, Utils } from "@arkecosystem/crypto";
 import { Asserts } from "@protokol/utils";
 import ByteBuffer from "bytebuffer";
 

--- a/packages/nft-base-transactions/README.md
+++ b/packages/nft-base-transactions/README.md
@@ -6,6 +6,7 @@
 A Protokol module providing NFT Transaction support for the ARK Core Blockchain Framework.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/index.ts
@@ -1,12 +1,15 @@
 import "jest-extended";
 
 import { Container, Contracts } from "@arkecosystem/core-kernel";
-import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
 import { Identities, Managers, Utils } from "@arkecosystem/crypto";
+import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
+import delay from "delay";
 
 jest.setTimeout(1200000);
 
 import { DatabaseService } from "@arkecosystem/core-database";
+import { DatabaseInteraction } from "@arkecosystem/core-state";
+import { StateBuilder } from "@arkecosystem/core-state/src/state-builder";
 import { Sandbox } from "@arkecosystem/core-test-framework/src";
 
 const sandbox: Sandbox = new Sandbox();
@@ -17,7 +20,7 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
     sandbox.withCoreOptions({
         flags: {
             token: "ark",
-            network: "unitnet",
+            network: "testnet",
             env: "test",
         },
         peers: {
@@ -28,7 +31,7 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
         await app.bootstrap({
             flags: {
                 token: "ark",
-                network: "unitnet",
+                network: "testnet",
                 env: "test",
                 processType: "core",
             },
@@ -86,17 +89,47 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
             }),
         );
 
-        await (databaseService as any).initializeActiveDelegates(1);
+        const databaseInteraction = app.get<DatabaseInteraction>(Container.Identifiers.DatabaseInteraction);
+
+        await (databaseInteraction as any).initializeActiveDelegates(1);
     });
 
     return sandbox.app;
 };
 
 export const tearDown = async (): Promise<void> => {
-    // const databaseService = sandbox.app.get<DatabaseService>(Container.Identifiers.DatabaseService);
-    // await databaseService.reset();
+    // before shutting down the app, we run wallet bootstrap from database state
+    // which we compare to the wallet state we got from actually running the chain from zero with the tests
+    const walletRepository = sandbox.app.getTagged<Contracts.State.WalletRepository>(
+        Container.Identifiers.WalletRepository,
+        "state",
+        "blockchain",
+    );
 
-    await sandbox.dispose();
+    const mapWallets = (wallet: Contracts.State.Wallet) => {
+        const walletAttributes = wallet.getAttributes();
+        if (walletAttributes.delegate) {
+            // we delete delegate attribute which is not built fully from StateBuilder
+            delete walletAttributes.delegate;
+        }
+        return {
+            publicKey: wallet.publicKey,
+            balance: wallet.balance,
+            nonce: wallet.nonce,
+            attributes: walletAttributes,
+        }
+    };
+    const sortWallets = (a: Contracts.State.Wallet, b: Contracts.State.Wallet) => a.publicKey!.localeCompare(b.publicKey!);
+
+    const allByPublicKey = walletRepository.allByPublicKey().map(w => w.clone()).sort(sortWallets).map(mapWallets);
+
+    walletRepository.reset();
+
+    await sandbox.app.resolve<StateBuilder>(StateBuilder).run();
+    await delay(2000); // if there is an issue with state builder, we wait a bit to be sure to catch it in the logs
+
+    const allByPublicKeyBootstrapped = walletRepository.allByPublicKey().map(w => w.clone()).sort(sortWallets).map(mapWallets);
+    expect(allByPublicKeyBootstrapped).toEqual(allByPublicKey);
 };
 
 export const passphrases = {

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/index.ts
@@ -20,7 +20,7 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
     sandbox.withCoreOptions({
         flags: {
             token: "ark",
-            network: "testnet",
+            network: "unitnet",
             env: "test",
         },
         peers: {

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/index.ts
@@ -1,8 +1,8 @@
 import "jest-extended";
 
 import { Container, Contracts } from "@arkecosystem/core-kernel";
-import { Identities, Managers, Utils } from "@arkecosystem/crypto";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
+import { Identities, Managers, Utils } from "@arkecosystem/crypto";
 import delay from "delay";
 
 jest.setTimeout(1200000);
@@ -117,18 +117,27 @@ export const tearDown = async (): Promise<void> => {
             balance: wallet.balance,
             nonce: wallet.nonce,
             attributes: walletAttributes,
-        }
+        };
     };
-    const sortWallets = (a: Contracts.State.Wallet, b: Contracts.State.Wallet) => a.publicKey!.localeCompare(b.publicKey!);
+    const sortWallets = (a: Contracts.State.Wallet, b: Contracts.State.Wallet) =>
+        a.publicKey!.localeCompare(b.publicKey!);
 
-    const allByPublicKey = walletRepository.allByPublicKey().map(w => w.clone()).sort(sortWallets).map(mapWallets);
+    const allByPublicKey = walletRepository
+        .allByPublicKey()
+        .map((w) => w.clone())
+        .sort(sortWallets)
+        .map(mapWallets);
 
     walletRepository.reset();
 
     await sandbox.app.resolve<StateBuilder>(StateBuilder).run();
     await delay(2000); // if there is an issue with state builder, we wait a bit to be sure to catch it in the logs
 
-    const allByPublicKeyBootstrapped = walletRepository.allByPublicKey().map(w => w.clone()).sort(sortWallets).map(mapWallets);
+    const allByPublicKeyBootstrapped = walletRepository
+        .allByPublicKey()
+        .map((w) => w.clone())
+        .sort(sortWallets)
+        .map(mapWallets);
     expect(allByPublicKeyBootstrapped).toEqual(allByPublicKey);
 };
 

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/__support__/transaction-factory.ts
@@ -1,5 +1,5 @@
 import { TransactionFactory } from "@arkecosystem/core-test-framework";
-import { Contracts } from "@packages/core-kernel";
+import { Contracts } from "@arkecosystem/core-kernel";
 import { Builders as NFTBuilders, Interfaces as NFTInterfaces } from "@protokol/nft-base-crypto";
 
 export class NFTBaseTransactionFactory extends TransactionFactory {

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn.test.ts
@@ -1,16 +1,24 @@
 import "@arkecosystem/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
-import { snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
-import { Identities } from "@arkecosystem/crypto";
+import { snoozeForBlock, TransactionFactory, getLastHeight } from "@arkecosystem/core-test-framework/src/utils";
+import { Identities, Interfaces } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 
 import * as support from "./__support__";
 import { NFTBaseTransactionFactory } from "./__support__/transaction-factory";
 
 let app: Contracts.Kernel.Application;
-beforeAll(async () => (app = await support.setUp()));
+let networkConfig: Interfaces.NetworkConfig;
+
+beforeAll(async () => {
+    app = await support.setUp();
+
+    // todo: remove the need for this and manual calls to withNetworkConfig on the transaction factory
+    networkConfig = app.get<Services.Config.ConfigRepository>(Container.Identifiers.ConfigRepository).get("crypto");
+});
+
 afterAll(async () => await support.tearDown());
 
 describe("NFT Burn functional tests", () => {
@@ -40,8 +48,10 @@ describe("NFT Burn functional tests", () => {
                         },
                     },
                 })
+                .withNetworkConfig(networkConfig)
                 .withPassphrase(secrets[0])
                 .createOne();
+
             registerCollectionId = nftRegisteredCollection.id;
 
             await expect(nftRegisteredCollection).toBeAccepted();
@@ -71,6 +81,7 @@ describe("NFT Burn functional tests", () => {
                 .NFTBurn({
                     nftId: nftCreate.id!,
                 })
+                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -91,6 +102,7 @@ describe("NFT Burn functional tests", () => {
                         mana: 2,
                     },
                 })
+                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -103,6 +115,7 @@ describe("NFT Burn functional tests", () => {
                 .NFTBurn({
                     nftId: nftCreate.id!,
                 })
+                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -111,6 +124,7 @@ describe("NFT Burn functional tests", () => {
                 .NFTBurn({
                     nftId: nftCreate.id!,
                 })
+                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .withNonce(nftBurn.nonce!.plus(1))
                 .createOne();
@@ -133,6 +147,7 @@ describe("NFT Burn functional tests", () => {
                         mana: 2,
                     },
                 })
+                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -146,6 +161,7 @@ describe("NFT Burn functional tests", () => {
                     nftIds: [nftCreate.id!],
                     recipientId: Identities.Address.fromPassphrase(secrets[2]),
                 })
+                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -155,6 +171,7 @@ describe("NFT Burn functional tests", () => {
                     nftId: nftCreate.id!,
                 })
                 .withNonce(nftTransfer.nonce!.plus(1))
+                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn.test.ts
@@ -2,7 +2,7 @@ import "@arkecosystem/core-test-framework/src/matchers";
 
 import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
-import { getLastHeight, snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
+import { snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
 import { Identities, Interfaces } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 
@@ -81,7 +81,6 @@ describe("NFT Burn functional tests", () => {
                 .NFTBurn({
                     nftId: nftCreate.id!,
                 })
-                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -102,7 +101,6 @@ describe("NFT Burn functional tests", () => {
                         mana: 2,
                     },
                 })
-                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -115,7 +113,6 @@ describe("NFT Burn functional tests", () => {
                 .NFTBurn({
                     nftId: nftCreate.id!,
                 })
-                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -124,7 +121,6 @@ describe("NFT Burn functional tests", () => {
                 .NFTBurn({
                     nftId: nftCreate.id!,
                 })
-                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .withNonce(nftBurn.nonce!.plus(1))
                 .createOne();
@@ -147,7 +143,6 @@ describe("NFT Burn functional tests", () => {
                         mana: 2,
                     },
                 })
-                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -161,7 +156,6 @@ describe("NFT Burn functional tests", () => {
                     nftIds: [nftCreate.id!],
                     recipientId: Identities.Address.fromPassphrase(secrets[2]),
                 })
-                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 
@@ -171,7 +165,6 @@ describe("NFT Burn functional tests", () => {
                     nftId: nftCreate.id!,
                 })
                 .withNonce(nftTransfer.nonce!.plus(1))
-                .withExpiration(getLastHeight(app) + 2)
                 .withPassphrase(secrets[0])
                 .createOne();
 

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-burn.test.ts
@@ -2,7 +2,7 @@ import "@arkecosystem/core-test-framework/src/matchers";
 
 import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
-import { snoozeForBlock, TransactionFactory, getLastHeight } from "@arkecosystem/core-test-framework/src/utils";
+import { getLastHeight, snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
 import { Identities, Interfaces } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-create.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-create.test.ts
@@ -1,16 +1,24 @@
 import "@arkecosystem/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
-import { Identities } from "@arkecosystem/crypto";
+import { Identities, Interfaces } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 
 import * as support from "./__support__";
 import { NFTBaseTransactionFactory } from "./__support__/transaction-factory";
 
 let app: Contracts.Kernel.Application;
-beforeAll(async () => (app = await support.setUp()));
+let networkConfig: Interfaces.NetworkConfig;
+
+beforeAll(async () => {
+    app = await support.setUp();
+
+    // todo: remove the need for this and manual calls to withNetworkConfig on the transaction factory
+    networkConfig = app.get<Services.Config.ConfigRepository>(Container.Identifiers.ConfigRepository).get("crypto");
+});
+
 afterAll(async () => await support.tearDown());
 
 describe("NFT Create functional tests", () => {
@@ -41,6 +49,7 @@ describe("NFT Create functional tests", () => {
                     },
                 })
                 .withPassphrase(secrets[0])
+                .withNetworkConfig(networkConfig)
                 .createOne();
 
             await expect(nftRegisteredCollection).toBeAccepted();

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-register-collection.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-register-collection.test.ts
@@ -1,16 +1,24 @@
 import "@arkecosystem/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
-import { Identities } from "@arkecosystem/crypto";
+import { Identities, Interfaces } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 
 import * as support from "./__support__";
 import { NFTBaseTransactionFactory } from "./__support__/transaction-factory";
 
 let app: Contracts.Kernel.Application;
-beforeAll(async () => (app = await support.setUp()));
+let networkConfig: Interfaces.NetworkConfig;
+
+beforeAll(async () => {
+    app = await support.setUp();
+
+    // todo: remove the need for this and manual calls to withNetworkConfig on the transaction factory
+    networkConfig = app.get<Services.Config.ConfigRepository>(Container.Identifiers.ConfigRepository).get("crypto");
+});
+
 afterAll(async () => await support.tearDown());
 
 describe("NFT Register collection functional tests", () => {
@@ -42,6 +50,7 @@ describe("NFT Register collection functional tests", () => {
                     },
                 })
                 .withPassphrase(secrets[0])
+                .withNetworkConfig(networkConfig)
                 .createOne();
 
             await expect(nftRegisteredCollection).toBeAccepted();

--- a/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-transfer.test.ts
+++ b/packages/nft-base-transactions/__tests__/functional/transaction-forging/nft-transfer.test.ts
@@ -1,16 +1,24 @@
 import "@arkecosystem/core-test-framework/src/matchers";
 
-import { Contracts } from "@arkecosystem/core-kernel";
+import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
 import { snoozeForBlock, TransactionFactory } from "@arkecosystem/core-test-framework/src/utils";
-import { Identities } from "@arkecosystem/crypto";
+import { Identities, Interfaces } from "@arkecosystem/crypto";
 import { generateMnemonic } from "bip39";
 
 import * as support from "./__support__";
 import { NFTBaseTransactionFactory } from "./__support__/transaction-factory";
 
 let app: Contracts.Kernel.Application;
-beforeAll(async () => (app = await support.setUp()));
+let networkConfig: Interfaces.NetworkConfig;
+
+beforeAll(async () => {
+    app = await support.setUp();
+
+    // todo: remove the need for this and manual calls to withNetworkConfig on the transaction factory
+    networkConfig = app.get<Services.Config.ConfigRepository>(Container.Identifiers.ConfigRepository).get("crypto");
+});
+
 afterAll(async () => await support.tearDown());
 
 describe("NFT Transfer Functional Tests", () => {
@@ -44,6 +52,7 @@ describe("NFT Transfer Functional Tests", () => {
                     },
                 })
                 .withPassphrase(secrets[0])
+                .withNetworkConfig(networkConfig)
                 .createOne();
 
             collectionId = nftRegisteredCollection.id;

--- a/packages/nft-base-transactions/__tests__/unit/utils/utils.ts
+++ b/packages/nft-base-transactions/__tests__/unit/utils/utils.ts
@@ -1,10 +1,10 @@
 import "jest-extended";
 
 import { Contracts } from "@arkecosystem/core-kernel";
+import { Transactions } from "@arkecosystem/crypto";
 import { Interfaces as NFTInterfaces, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 
 import { INFTCollections } from "../../../src/interfaces";
-import { Transactions } from "@arkecosystem/crypto";
 
 export const collectionWalletCheck = (
     wallet: Contracts.State.Wallet,
@@ -23,4 +23,4 @@ export const deregisterTransactions = () => {
     Transactions.TransactionRegistry.deregisterTransactionType(NFTTransactions.NFTCreateTransaction);
     Transactions.TransactionRegistry.deregisterTransactionType(NFTTransactions.NFTBurnTransaction);
     Transactions.TransactionRegistry.deregisterTransactionType(NFTTransactions.NFTTransferTransaction);
-}
+};

--- a/packages/nft-base-transactions/package.json
+++ b/packages/nft-base-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-base-transactions",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "description": "Transaction Types For Base NFT Core Support",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -47,7 +47,7 @@
         "@arkecosystem/core-state": "^3.0.0-alpha.1",
         "@arkecosystem/core-transactions": "^3.0.0-alpha.1",
         "@arkecosystem/crypto": "^3.0.0-alpha.1",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.20"
+        "@protokol/nft-base-crypto": "^1.0.0-beta.21"
     },
     "devDependencies": {
         "@types/prettier": "^2.0.0",

--- a/packages/nft-base-transactions/package.json
+++ b/packages/nft-base-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-base-transactions",
-    "version": "1.0.0-beta.8",
+    "version": "1.0.0-beta.20",
     "description": "Transaction Types For Base NFT Core Support",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -47,7 +47,7 @@
         "@arkecosystem/core-state": "^3.0.0-alpha.0",
         "@arkecosystem/core-transactions": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.13"
+        "@protokol/nft-base-crypto": "^1.0.0-beta.20"
     },
     "devDependencies": {
         "@types/prettier": "^2.0.0",

--- a/packages/nft-base-transactions/package.json
+++ b/packages/nft-base-transactions/package.json
@@ -42,11 +42,11 @@
         "test:functional:coverage": "cross-env CORE_ENV=test jest __tests__/functional --coverage --forceExit"
     },
     "dependencies": {
-        "@arkecosystem/core-database": "^3.0.0-alpha.0",
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
-        "@arkecosystem/core-state": "^3.0.0-alpha.0",
-        "@arkecosystem/core-transactions": "^3.0.0-alpha.0",
-        "@arkecosystem/crypto": "^3.0.0-alpha.0",
+        "@arkecosystem/core-database": "^3.0.0-alpha.1",
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.1",
+        "@arkecosystem/core-state": "^3.0.0-alpha.1",
+        "@arkecosystem/core-transactions": "^3.0.0-alpha.1",
+        "@arkecosystem/crypto": "^3.0.0-alpha.1",
         "@protokol/nft-base-crypto": "^1.0.0-beta.20"
     },
     "devDependencies": {

--- a/packages/nft-base-transactions/src/handlers/nft-transfer.ts
+++ b/packages/nft-base-transactions/src/handlers/nft-transfer.ts
@@ -57,8 +57,9 @@ export class NFTTransferHandler extends NFTBaseTransactionHandler {
             const senderTokensWallet = senderWallet.getAttribute<INFTTokens>("nft.base.tokenIds", {});
             for (const token of nftTransferAsset.nftIds) {
                 delete senderTokensWallet[token];
-                this.walletRepository.forgetByIndex(NFTIndexers.NFTTokenIndexer, token);
+                this.walletRepository.getIndex(NFTIndexers.NFTTokenIndexer).forget(token);
             }
+
             senderWallet.setAttribute<INFTTokens>("nft.base.tokenIds", senderTokensWallet);
 
             const recipientTokensWallet = recipientWallet.getAttribute<INFTTokens>("nft.base.tokenIds", {});
@@ -67,6 +68,8 @@ export class NFTTransferHandler extends NFTBaseTransactionHandler {
             }
             recipientWallet.setAttribute<INFTTokens>("nft.base.tokenIds", recipientTokensWallet);
 
+            // TODO - this can be removed as we directly call forget above. Needs testing/performance analysis
+            // TODO - need to operate the indexes directly e.g. set/forget and DO NOT CALL general index methods
             this.walletRepository.index(senderWallet);
             this.walletRepository.index(recipientWallet);
         }

--- a/packages/nft-client/README.md
+++ b/packages/nft-client/README.md
@@ -6,6 +6,7 @@
 A Protokol module providing NFT API support for the ARK Core Blockchain Framework.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-client/package.json
+++ b/packages/nft-client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@protokol/nft-client",
 	"description": "A Light TypeScript Client Supporting NFT And Public ARK REST API",
-	"version": "1.0.0-beta.8",
+	"version": "1.0.0-beta.20",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"

--- a/packages/nft-client/package.json
+++ b/packages/nft-client/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "@protokol/nft-client",
-	"description": "A Light TypeScript Client Supporting NFT And Public ARK REST API",
-	"version": "1.0.0-beta.20",
+    "name": "@protokol/nft-client",
+    "description": "A Light TypeScript Client Supporting NFT And Public ARK REST API",
+    "version": "1.0.0-beta.20",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"
@@ -18,51 +18,51 @@
         "nft",
         "blockchain"
     ],
-	"contributors": [
+    "contributors": [
         "Žan Kovač <zan@protokol.com",
         "Kristjan Košič <kristjan@protokol.com>"
     ],
-	"license": "CC-BY-NC-SA-4.0",
-	"files": [
-		"/dist"
-	],
-	"main": "dist/index",
-	"types": "dist/index",
-	"scripts": {
-		"build": "yarn clean && tsc",
-		"build:watch": "yarn build -w",
-		"clean": "rimraf .coverage dist tmp",
-		"format": "yarn lint && yarn prettier",
-		"lint": "tslint -c tslint.json -p tslint.json 'src/**/*.ts' --fix",
-		"prepublishOnly": "yarn build",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
-		"test": "jest",
-		"test:watch": "jest --watchAll"
-	},
-	"dependencies": {
+    "license": "CC-BY-NC-SA-4.0",
+    "files": [
+        "/dist"
+    ],
+    "main": "dist/index",
+    "types": "dist/index",
+    "scripts": {
+        "build": "yarn clean && tsc",
+        "build:watch": "yarn build -w",
+        "clean": "rimraf .coverage dist tmp",
+        "format": "yarn lint && yarn prettier",
+        "lint": "tslint -c tslint.json -p tslint.json 'src/**/*.ts' --fix",
+        "prepublishOnly": "yarn build",
+        "prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
+        "test": "jest",
+        "test:watch": "jest --watchAll"
+    },
+    "dependencies": {
         "@arkecosystem/client": "^1.1.4"
-	},
-	"devDependencies": {
-		"@types/jest": "^25.1.4",
-		"@types/nock": "^11.1.0",
-		"@types/prettier": "^2.0.0",
-		"@types/rimraf": "^3.0.0",
-		"@typeskrift/tsconfig": "^0.1.2",
-		"@typeskrift/tslint": "^0.1.5",
-		"codecov": "^3.6.5",
-		"cross-env": "^7.0.2",
-		"jest": "^26.0.0",
-		"jest-extended": "^0.11.5",
-		"nock": "^12.0.3",
-		"prettier": "^2.0.0",
-		"rimraf": "^3.0.2",
-		"ts-jest": "^26.0.0",
-		"tslint": "^6.1.0",
-		"typescript": "^3.8.3"
-	},
-	"engines": {
-		"node": ">=10.x"
-	},
+    },
+    "devDependencies": {
+        "@types/jest": "^25.1.4",
+        "@types/nock": "^11.1.0",
+        "@types/prettier": "^2.0.0",
+        "@types/rimraf": "^3.0.0",
+        "@typeskrift/tsconfig": "^0.1.2",
+        "@typeskrift/tslint": "^0.1.5",
+        "codecov": "^3.6.5",
+        "cross-env": "^7.0.2",
+        "jest": "^26.0.0",
+        "jest-extended": "^0.11.5",
+        "nock": "^12.0.3",
+        "prettier": "^2.0.0",
+        "rimraf": "^3.0.2",
+        "ts-jest": "^26.0.0",
+        "tslint": "^6.1.0",
+        "typescript": "^3.8.3"
+    },
+    "engines": {
+        "node": ">=10.x"
+    },
     "publishConfig": {
         "access": "public"
     }

--- a/packages/nft-client/package.json
+++ b/packages/nft-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@protokol/nft-client",
     "description": "A Light TypeScript Client Supporting NFT And Public ARK REST API",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"

--- a/packages/nft-examples/README.md
+++ b/packages/nft-examples/README.md
@@ -6,6 +6,7 @@
 A Protokol module providing examples for NFT functionalities.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-examples/package.json
+++ b/packages/nft-examples/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@protokol/nft-examples",
 	"description": "A TypeScript Examples Supporting Protokol NFT functionalities",
-	"version": "1.0.0-beta.8",
+	"version": "1.0.0-beta.20",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"
@@ -37,10 +37,10 @@
 		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\""
 	},
 	"dependencies": {
-        "@protokol/nft-client": "^1.0.0-beta.8",
+        "@protokol/nft-client": "^1.0.0-beta.20",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.13",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.13"
+        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.20"
     },
 	"devDependencies": {
 		"@types/prettier": "^2.0.0",

--- a/packages/nft-examples/package.json
+++ b/packages/nft-examples/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "@protokol/nft-examples",
-	"description": "A TypeScript Examples Supporting Protokol NFT functionalities",
-	"version": "1.0.0-beta.20",
+    "name": "@protokol/nft-examples",
+    "description": "A TypeScript Examples Supporting Protokol NFT functionalities",
+    "version": "1.0.0-beta.20",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"
@@ -18,44 +18,44 @@
         "nft",
         "blockchain"
     ],
-	"contributors": [
+    "contributors": [
         "Žan Kovač <zan@protokol.com",
         "Kristjan Košič <kristjan@protokol.com>"
     ],
-	"license": "CC-BY-NC-SA-4.0",
-	"files": [
-		"/dist"
-	],
-	"main": "dist/index",
-	"types": "dist/index",
-	"scripts": {
-		"build": "yarn clean && tsc",
-		"build:watch": "yarn build -w",
-		"clean": "rimraf .coverage dist tmp",
-		"format": "yarn lint && yarn prettier",
-		"lint": "tslint -c tslint.json -p tslint.json 'src/**/*.ts' --fix",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\""
-	},
-	"dependencies": {
+    "license": "CC-BY-NC-SA-4.0",
+    "files": [
+        "/dist"
+    ],
+    "main": "dist/index",
+    "types": "dist/index",
+    "scripts": {
+        "build": "yarn clean && tsc",
+        "build:watch": "yarn build -w",
+        "clean": "rimraf .coverage dist tmp",
+        "format": "yarn lint && yarn prettier",
+        "lint": "tslint -c tslint.json -p tslint.json 'src/**/*.ts' --fix",
+        "prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\""
+    },
+    "dependencies": {
         "@protokol/nft-client": "^1.0.0-beta.20",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
         "@protokol/nft-base-crypto": "^1.0.0-beta.20",
         "@protokol/nft-exchange-crypto": "^1.0.0-beta.20"
     },
-	"devDependencies": {
-		"@types/prettier": "^2.0.0",
-		"@types/rimraf": "^3.0.0",
-		"@typeskrift/tsconfig": "^0.1.2",
-		"@typeskrift/tslint": "^0.1.5",
-		"cross-env": "^7.0.2",
-		"prettier": "^2.0.0",
-		"rimraf": "^3.0.2",
-		"tslint": "^6.1.0",
-		"typescript": "^3.8.3"
-	},
-	"engines": {
-		"node": ">=10.x"
-	},
+    "devDependencies": {
+        "@types/prettier": "^2.0.0",
+        "@types/rimraf": "^3.0.0",
+        "@typeskrift/tsconfig": "^0.1.2",
+        "@typeskrift/tslint": "^0.1.5",
+        "cross-env": "^7.0.2",
+        "prettier": "^2.0.0",
+        "rimraf": "^3.0.2",
+        "tslint": "^6.1.0",
+        "typescript": "^3.8.3"
+    },
+    "engines": {
+        "node": ">=10.x"
+    },
     "publishConfig": {
         "access": "public"
     }

--- a/packages/nft-examples/package.json
+++ b/packages/nft-examples/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@protokol/nft-examples",
     "description": "A TypeScript Examples Supporting Protokol NFT functionalities",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"
@@ -37,9 +37,9 @@
         "prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\""
     },
     "dependencies": {
-        "@protokol/nft-client": "^1.0.0-beta.20",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.20"
+        "@protokol/nft-client": "^1.0.0-beta.21",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.21",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.21"
     },
     "devDependencies": {
         "@types/prettier": "^2.0.0",

--- a/packages/nft-examples/package.json
+++ b/packages/nft-examples/package.json
@@ -38,7 +38,6 @@
     },
     "dependencies": {
         "@protokol/nft-client": "^1.0.0-beta.20",
-        "@arkecosystem/crypto": "^3.0.0-alpha.0",
         "@protokol/nft-base-crypto": "^1.0.0-beta.20",
         "@protokol/nft-exchange-crypto": "^1.0.0-beta.20"
     },

--- a/packages/nft-examples/src/base/nft-burn.ts
+++ b/packages/nft-examples/src/base/nft-burn.ts
@@ -1,20 +1,19 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { NFTConnection } from "@protokol/nft-client";
 
 export const NFTBurn = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTBurnTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTBurnTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NFTBurnBuilder()

--- a/packages/nft-examples/src/base/nft-create.ts
+++ b/packages/nft-examples/src/base/nft-create.ts
@@ -1,20 +1,19 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { NFTConnection } from "@protokol/nft-client";
 
 export const NFTCreate = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTCreateTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTCreateTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NFTCreateBuilder()

--- a/packages/nft-examples/src/base/nft-register-collection.ts
+++ b/packages/nft-examples/src/base/nft-register-collection.ts
@@ -5,7 +5,9 @@ export const NFTRegisterCollection = async () => {
     // Configure manager and register transaction type
     ARKCrypto.Managers.configManager.setFromPreset("testnet");
     ARKCrypto.Managers.configManager.setHeight(2);
-    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTRegisterCollectionTransaction);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(
+        NFTTransactions.NFTRegisterCollectionTransaction,
+    );
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");

--- a/packages/nft-examples/src/base/nft-register-collection.ts
+++ b/packages/nft-examples/src/base/nft-register-collection.ts
@@ -1,20 +1,19 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { NFTConnection } from "@protokol/nft-client";
 
 export const NFTRegisterCollection = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTRegisterCollectionTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTRegisterCollectionTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NFTRegisterCollectionBuilder()

--- a/packages/nft-examples/src/base/nft-transfer.ts
+++ b/packages/nft-examples/src/base/nft-transfer.ts
@@ -1,25 +1,24 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-base-crypto";
 import { NFTConnection } from "@protokol/nft-client";
 
 export const NFTTransfer = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTTransferTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTTransferTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NFTTransferBuilder()
         .NFTTransferAsset({
-            recipientId: Identities.Address.fromPassphrase(passphrase),
+            recipientId: ARKCrypto.Identities.Address.fromPassphrase(passphrase),
             nftIds: ["7373bbe5524898faec40bfcd12c6161981771f3be6426404208784831f4b0d02"],
         })
         .nonce(senderNonce.toFixed())

--- a/packages/nft-examples/src/exchange/nft-accept-trade.ts
+++ b/packages/nft-examples/src/exchange/nft-accept-trade.ts
@@ -1,20 +1,19 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import { NFTConnection } from "@protokol/nft-client";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
 
 export const NFTAcceptTrade = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTAcceptTradeTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTAcceptTradeTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NftAcceptTradeBuilder()

--- a/packages/nft-examples/src/exchange/nft-auction-cancel.ts
+++ b/packages/nft-examples/src/exchange/nft-auction-cancel.ts
@@ -1,20 +1,19 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import { NFTConnection } from "@protokol/nft-client";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
 
 export const NFTAuctionCancel = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTAuctionCancelTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTAuctionCancelTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NFTAuctionCancelBuilder()

--- a/packages/nft-examples/src/exchange/nft-auction.ts
+++ b/packages/nft-examples/src/exchange/nft-auction.ts
@@ -1,25 +1,24 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import { NFTConnection } from "@protokol/nft-client";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
 
 export const NFTAuction = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTAuctionTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTAuctionTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NFTAuctionBuilder()
         .NFTAuctionAsset({
-            startAmount: Utils.BigNumber.make("1000"),
+            startAmount: ARKCrypto.Utils.BigNumber.make("1000"),
             expiration: {
                 blockHeight: 1000000,
             },

--- a/packages/nft-examples/src/exchange/nft-bid-cancel.ts
+++ b/packages/nft-examples/src/exchange/nft-bid-cancel.ts
@@ -1,20 +1,19 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import { NFTConnection } from "@protokol/nft-client";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
 
 export const NFTBidCancel = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTBidCancelTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTBidCancelTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NFTBidCancelBuilder()

--- a/packages/nft-examples/src/exchange/nft-bid.ts
+++ b/packages/nft-examples/src/exchange/nft-bid.ts
@@ -1,25 +1,24 @@
-import { Identities, Managers, Transactions, Utils } from "@arkecosystem/crypto";
 import { NFTConnection } from "@protokol/nft-client";
-import { Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
+import { ARKCrypto, Builders, Transactions as NFTTransactions } from "@protokol/nft-exchange-crypto";
 
 export const NFTBid = async () => {
     // Configure manager and register transaction type
-    Managers.configManager.setFromPreset("testnet");
-    Managers.configManager.setHeight(2);
-    Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTBidTransaction);
+    ARKCrypto.Managers.configManager.setFromPreset("testnet");
+    ARKCrypto.Managers.configManager.setHeight(2);
+    ARKCrypto.Transactions.TransactionRegistry.registerTransactionType(NFTTransactions.NFTBidTransaction);
 
     // Configure our API client
     const client = new NFTConnection("http://nft.protokol.com:4003/api");
     const passphrase = "clay harbor enemy utility margin pretty hub comic piece aerobic umbrella acquire";
 
     // Step 1: Retrieve the nonce of the sender wallet
-    const senderWallet = await client.api("wallets").get(Identities.Address.fromPassphrase(passphrase));
-    const senderNonce = Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
+    const senderWallet = await client.api("wallets").get(ARKCrypto.Identities.Address.fromPassphrase(passphrase));
+    const senderNonce = ARKCrypto.Utils.BigNumber.make(senderWallet.body.data.nonce).plus(1);
 
     // Step 2: Create the transaction
     const transaction = new Builders.NFTBidBuilder()
         .NFTBidAsset({
-            bidAmount: Utils.BigNumber.make("1100"),
+            bidAmount: ARKCrypto.Utils.BigNumber.make("1100"),
             auctionId: "717ce9f6dff858c4972b067a1fce8ea72fb1c4ac60c4a75cc8e9993dbbe7541a",
         })
         .nonce(senderNonce.toFixed())

--- a/packages/nft-exchange-api/README.md
+++ b/packages/nft-exchange-api/README.md
@@ -6,6 +6,7 @@
 A Protokol module providing NFT Exchange API Support for the ARK Core Blockchain Framework.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-exchange-api/package.json
+++ b/packages/nft-exchange-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-exchange-api",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "description": "REST API For Exchange NFT Functionality",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -46,12 +46,12 @@
         "@hapi/boom": "^9.0.0",
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",
-        "@protokol/nft-exchange-transactions": "^1.0.0-beta.20",
+        "@protokol/nft-exchange-transactions": "^1.0.0-beta.21",
         "latest-version": "^5.1.0"
     },
     "devDependencies": {
         "@arkecosystem/crypto": "^3.0.0-alpha.1",
-        "@protokol/nft-base-transactions": "^1.0.0-beta.20",
+        "@protokol/nft-base-transactions": "^1.0.0-beta.21",
         "@types/hapi__boom": "^7.4.1",
         "@types/hapi__joi": "^16.0.4",
         "@types/prettier": "^2.0.0",

--- a/packages/nft-exchange-api/package.json
+++ b/packages/nft-exchange-api/package.json
@@ -41,17 +41,17 @@
         "test:integration:coverage": "cross-env CORE_ENV=test jest __tests__/integration --coverage --runInBand --forceExit"
     },
     "dependencies": {
-        "@arkecosystem/core-api": "^3.0.0-alpha.0",
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
+        "@arkecosystem/core-api": "^3.0.0-alpha.1",
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.1",
         "@hapi/boom": "^9.0.0",
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",
-        "latest-version": "^5.1.0",
-        "@protokol/nft-exchange-transactions": "^1.0.0-beta.20"
+        "@protokol/nft-exchange-transactions": "^1.0.0-beta.20",
+        "latest-version": "^5.1.0"
     },
     "devDependencies": {
+        "@arkecosystem/crypto": "^3.0.0-alpha.1",
         "@protokol/nft-base-transactions": "^1.0.0-beta.20",
-        "@arkecosystem/crypto": "3.0.0-alpha.0",
         "@types/hapi__boom": "^7.4.1",
         "@types/hapi__joi": "^16.0.4",
         "@types/prettier": "^2.0.0",

--- a/packages/nft-exchange-api/package.json
+++ b/packages/nft-exchange-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-exchange-api",
-    "version": "1.0.0-beta.8",
+    "version": "1.0.0-beta.20",
     "description": "REST API For Exchange NFT Functionality",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -47,10 +47,10 @@
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",
         "latest-version": "^5.1.0",
-        "@protokol/nft-exchange-transactions": "^1.0.0-beta.8"
+        "@protokol/nft-exchange-transactions": "^1.0.0-beta.20"
     },
     "devDependencies": {
-        "@protokol/nft-base-transactions": "^1.0.0-beta.8",
+        "@protokol/nft-base-transactions": "^1.0.0-beta.20",
         "@arkecosystem/crypto": "3.0.0-alpha.0",
         "@types/hapi__boom": "^7.4.1",
         "@types/hapi__joi": "^16.0.4",

--- a/packages/nft-exchange-crypto/README.md
+++ b/packages/nft-exchange-crypto/README.md
@@ -6,6 +6,7 @@
 A Protokol module providing NFT Exchange Transaction support for the ARK Core Blockchain Framework.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-exchange-crypto/package.json
+++ b/packages/nft-exchange-crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-exchange-crypto",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "description": "Transaction Builders For Exchange NFT Transaction Types",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -40,7 +40,7 @@
         "test:unit:coverage": "cross-env jest __tests__/unit --coverage"
     },
     "dependencies": {
-        "@protokol/utils": "^1.0.0-beta.20",
+        "@protokol/utils": "^1.0.0-beta.21",
         "@arkecosystem/crypto": "^3.0.0-alpha.1",
         "bytebuffer": "^5.0.1"
     },

--- a/packages/nft-exchange-crypto/package.json
+++ b/packages/nft-exchange-crypto/package.json
@@ -40,12 +40,12 @@
         "test:unit:coverage": "cross-env jest __tests__/unit --coverage"
     },
     "dependencies": {
-        "@arkecosystem/crypto": "^3.0.0-alpha.0",
         "@protokol/utils": "^1.0.0-beta.20",
+        "@arkecosystem/crypto": "^3.0.0-alpha.1",
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0"
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/nft-exchange-crypto/package.json
+++ b/packages/nft-exchange-crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-exchange-crypto",
-    "version": "1.0.0-beta.13",
+    "version": "1.0.0-beta.20",
     "description": "Transaction Builders For Exchange NFT Transaction Types",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -41,7 +41,7 @@
     },
     "dependencies": {
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@protokol/utils": "^1.0.0-beta.3",
+        "@protokol/utils": "^1.0.0-beta.20",
         "bytebuffer": "^5.0.1"
     },
     "devDependencies": {

--- a/packages/nft-exchange-transactions/README.md
+++ b/packages/nft-exchange-transactions/README.md
@@ -6,6 +6,7 @@
 A Protokol module providing NFT Exchange Transaction support for the ARK Core Blockchain Framework.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/__support__/index.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/__support__/index.ts
@@ -3,10 +3,13 @@ import "jest-extended";
 import { Container, Contracts } from "@arkecosystem/core-kernel";
 import secrets from "@arkecosystem/core-test-framework/src/internal/passphrases.json";
 import { Identities, Managers, Utils } from "@arkecosystem/crypto";
+import delay from "delay";
 
 jest.setTimeout(1200000);
 
 import { DatabaseService } from "@arkecosystem/core-database";
+import { DatabaseInteraction } from "@arkecosystem/core-state";
+import { StateBuilder } from "@arkecosystem/core-state/src/state-builder";
 import { Sandbox } from "@arkecosystem/core-test-framework/src";
 
 const sandbox: Sandbox = new Sandbox();
@@ -28,7 +31,7 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
         await app.bootstrap({
             flags: {
                 token: "ark",
-                network: "unitnet",
+                network: "testnet",
                 env: "test",
                 processType: "core",
             },
@@ -39,7 +42,6 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
                     "@arkecosystem/core-transactions",
                     "@arkecosystem/core-magistrate-transactions",
                     "@protokol/nft-base-transactions",
-                    "@protokol/nft-exchange-transactions",
                     "@arkecosystem/core-transaction-pool",
                     "@arkecosystem/core-p2p",
                     "@arkecosystem/core-blockchain",
@@ -87,17 +89,56 @@ export const setUp = async (): Promise<Contracts.Kernel.Application> => {
             }),
         );
 
-        await (databaseService as any).initializeActiveDelegates(1);
+        const databaseInteraction = app.get<DatabaseInteraction>(Container.Identifiers.DatabaseInteraction);
+
+        await (databaseInteraction as any).initializeActiveDelegates(1);
     });
 
     return sandbox.app;
 };
 
 export const tearDown = async (): Promise<void> => {
-    // const databaseService = sandbox.app.get<DatabaseService>(Container.Identifiers.DatabaseService);
-    // await databaseService.reset();
+    // before shutting down the app, we run wallet bootstrap from database state
+    // which we compare to the wallet state we got from actually running the chain from zero with the tests
+    const walletRepository = sandbox.app.getTagged<Contracts.State.WalletRepository>(
+        Container.Identifiers.WalletRepository,
+        "state",
+        "blockchain",
+    );
 
-    await sandbox.dispose();
+    const mapWallets = (wallet: Contracts.State.Wallet) => {
+        const walletAttributes = wallet.getAttributes();
+        if (walletAttributes.delegate) {
+            // we delete delegate attribute which is not built fully from StateBuilder
+            delete walletAttributes.delegate;
+        }
+        return {
+            publicKey: wallet.publicKey,
+            balance: wallet.balance,
+            nonce: wallet.nonce,
+            attributes: walletAttributes,
+        };
+    };
+    const sortWallets = (a: Contracts.State.Wallet, b: Contracts.State.Wallet) =>
+        a.publicKey!.localeCompare(b.publicKey!);
+
+    const allByPublicKey = walletRepository
+        .allByPublicKey()
+        .map((w) => w.clone())
+        .sort(sortWallets)
+        .map(mapWallets);
+
+    walletRepository.reset();
+
+    await sandbox.app.resolve<StateBuilder>(StateBuilder).run();
+    await delay(2000); // if there is an issue with state builder, we wait a bit to be sure to catch it in the logs
+
+    const allByPublicKeyBootstrapped = walletRepository
+        .allByPublicKey()
+        .map((w) => w.clone())
+        .sort(sortWallets)
+        .map(mapWallets);
+    expect(allByPublicKeyBootstrapped).toEqual(allByPublicKey);
 };
 
 export const passphrases = {

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-accept-trade.test.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-accept-trade.test.ts
@@ -257,7 +257,6 @@ describe("NFT Accept Trade functional tests", () => {
             await snoozeForBlock(1);
             await expect(nftAcceptTrade.id).toBeForged();
             await expect(nftAcceptTradeTwo.id).not.toBeForged();
-
         });
 
         it("should reject because bid was canceled", async () => {

--- a/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-bid-cancel.test.ts
+++ b/packages/nft-exchange-transactions/__tests__/functional/transaction-forging/nft-bid-cancel.test.ts
@@ -450,7 +450,9 @@ describe("NFT Bid Cancel functional tests", () => {
 
             // Send funds to multi signature wallet
             const multiSigAddress = Identities.Address.fromMultiSignatureAsset(multiSignature.asset!.multiSignature!);
-            const multiSigPublicKey = Identities.PublicKey.fromMultiSignatureAsset(multiSignature.asset!.multiSignature!);
+            const multiSigPublicKey = Identities.PublicKey.fromMultiSignatureAsset(
+                multiSignature.asset!.multiSignature!,
+            );
 
             const multiSignatureFunds = TransactionFactory.initialize(app)
                 .transfer(multiSigAddress, 100 * 1e8)

--- a/packages/nft-exchange-transactions/package.json
+++ b/packages/nft-exchange-transactions/package.json
@@ -42,14 +42,14 @@
         "test:functional:coverage": "cross-env CORE_ENV=test jest __tests__/functional --coverage --forceExit"
     },
     "dependencies": {
-        "@arkecosystem/core-database": "^3.0.0-alpha.0",
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
-        "@arkecosystem/core-state": "^3.0.0-alpha.0",
-        "@arkecosystem/core-transactions": "^3.0.0-alpha.0",
-        "@arkecosystem/crypto": "^3.0.0-alpha.0",
         "@protokol/nft-exchange-crypto": "^1.0.0-beta.20",
         "@protokol/nft-base-crypto": "^1.0.0-beta.20",
-        "@protokol/nft-base-transactions": "^1.0.0-beta.20"
+        "@protokol/nft-base-transactions": "^1.0.0-beta.20",
+        "@arkecosystem/core-database": "^3.0.0-alpha.1",
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.1",
+        "@arkecosystem/core-state": "^3.0.0-alpha.1",
+        "@arkecosystem/core-transactions": "^3.0.0-alpha.1",
+        "@arkecosystem/crypto": "^3.0.0-alpha.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/nft-exchange-transactions/package.json
+++ b/packages/nft-exchange-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-exchange-transactions",
-    "version": "1.0.0-beta.8",
+    "version": "1.0.0-beta.20",
     "description": "Transaction Types For Exchange NFT Core Support",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -47,9 +47,9 @@
         "@arkecosystem/core-state": "^3.0.0-alpha.0",
         "@arkecosystem/core-transactions": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.13",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.13",
-        "@protokol/nft-base-transactions": "^1.0.0-beta.8"
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.20",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
+        "@protokol/nft-base-transactions": "^1.0.0-beta.20"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/nft-exchange-transactions/package.json
+++ b/packages/nft-exchange-transactions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-exchange-transactions",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "description": "Transaction Types For Exchange NFT Core Support",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -42,9 +42,9 @@
         "test:functional:coverage": "cross-env CORE_ENV=test jest __tests__/functional --coverage --forceExit"
     },
     "dependencies": {
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.20",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
-        "@protokol/nft-base-transactions": "^1.0.0-beta.20",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.21",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.21",
+        "@protokol/nft-base-transactions": "^1.0.0-beta.21",
         "@arkecosystem/core-database": "^3.0.0-alpha.1",
         "@arkecosystem/core-kernel": "^3.0.0-alpha.1",
         "@arkecosystem/core-state": "^3.0.0-alpha.1",

--- a/packages/nft-generator-api/README.md
+++ b/packages/nft-generator-api/README.md
@@ -1,4 +1,5 @@
 ![Img](nft-generator-api.png)
+
 # NFT-GENERATOR-API
 
 A helper module for quickly generating transactions.
@@ -6,6 +7,7 @@ A helper module for quickly generating transactions.
 #### FOR TESTING ENV ONLY! DO NOT USE IN PRODUCTION
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/nft-generator-api/package.json
+++ b/packages/nft-generator-api/package.json
@@ -38,8 +38,8 @@
         "pretest": "bash ../../../scripts/pre-test.sh"
     },
     "dependencies": {
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
-        "@arkecosystem/core-api": "^3.0.0-alpha.0",
+        "@arkecosystem/core-api": "^3.0.0-alpha.1",
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.1",
         "@hapi/boom": "^9.0.0",
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",

--- a/packages/nft-generator-api/package.json
+++ b/packages/nft-generator-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-generator-api",
-    "version": "1.0.0-beta.8",
+    "version": "1.0.0-beta.20",
     "description": "NFT Transaction Generator – TEST ENV Only",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -43,10 +43,10 @@
         "@hapi/boom": "^9.0.0",
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.13",
-        "@protokol/nft-base-transactions": "^1.0.0-beta.8",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.13",
-        "@protokol/nft-exchange-transactions": "^1.0.0-beta.8",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
+        "@protokol/nft-base-transactions": "^1.0.0-beta.20",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.20",
+        "@protokol/nft-exchange-transactions": "^1.0.0-beta.20",
         "got": "^11.0.3"
     },
     "devDependencies": {

--- a/packages/nft-generator-api/package.json
+++ b/packages/nft-generator-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-generator-api",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "description": "NFT Transaction Generator – TEST ENV Only",
     "license": "CC-BY-NC-SA-4.0",
     "homepage": "https://docs.protokol.com/nft/",
@@ -43,10 +43,8 @@
         "@hapi/boom": "^9.0.0",
         "@hapi/hapi": "^19.0.0",
         "@hapi/joi": "^17.1.0",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
-        "@protokol/nft-base-transactions": "^1.0.0-beta.20",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.20",
-        "@protokol/nft-exchange-transactions": "^1.0.0-beta.20",
+        "@protokol/nft-base-transactions": "^1.0.0-beta.21",
+        "@protokol/nft-exchange-transactions": "^1.0.0-beta.21",
         "got": "^11.0.3"
     },
     "devDependencies": {

--- a/packages/nft-generator-api/tsconfig.json
+++ b/packages/nft-generator-api/tsconfig.json
@@ -3,7 +3,5 @@
     "compilerOptions": {
         "outDir": "dist"
     },
-    "include": [
-        "src/**/**.ts"
-    ]
+    "include": ["src/**/**.ts"]
 }

--- a/packages/nft-tx-tester/README.md
+++ b/packages/nft-tx-tester/README.md
@@ -9,31 +9,39 @@ A Protokol module providing command line utility for creating and broadcasting N
 ### Source Code Setup
 
 #### Install the dependencies
+
 ```bash
 yarn
 ```
+
 #### Run NFT Tx Tester
+
 Tester-CLI has 4 commands:
-- send
-- list-wallets
-- save-wallets
-- help
+
+-   send
+-   list-wallets
+-   save-wallets
+-   help
 
 To get general help use:
+
 ```bash
 ./bin/run --help
 ```
 
 It is possible to get help for each subcommand
-- `./bin/run send --help`
-- `./bin/run send:transfer --help`
-- `./bin/run send:ipfs --help`
-- ...
+
+-   `./bin/run send --help`
+-   `./bin/run send:transfer --help`
+-   `./bin/run send:ipfs --help`
+-   ...
 
 For each subcommand check optional flags. Here is one run example
+
 ```bash
 ./bin/run send:transfer -p="hurdle pulse sheriff anchor two hope income pattern hazard bacon book night" -q=2
 ```
 
 # Contact Us For Support And Custom Development
+
 info@protokol.com

--- a/packages/nft-tx-tester/package.json
+++ b/packages/nft-tx-tester/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-tx-tester",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "description": "A simple command line utility to create and broadcast NFT transactions.",
     "license": "MIT",
     "homepage": "https://docs.protokol.com/nft/",
@@ -53,8 +53,8 @@
         "@arkecosystem/crypto": "^3.0.0-alpha.1",
         "@oclif/command": "^1",
         "@oclif/plugin-help": "^3",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.20",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.21",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.21",
         "fs-extra": "^9.0.1"
     },
     "devDependencies": {

--- a/packages/nft-tx-tester/package.json
+++ b/packages/nft-tx-tester/package.json
@@ -48,18 +48,18 @@
         "compile": "../../../node_modules/typescript/bin/tsc"
     },
     "dependencies": {
-        "@arkecosystem/core-magistrate-crypto": "^3.0.0-alpha.0",
-        "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
-        "@arkecosystem/crypto": "^3.0.0-alpha.0",
-        "fs-extra": "^9.0.1",
+        "@arkecosystem/core-kernel": "^3.0.0-alpha.1",
+        "@arkecosystem/core-magistrate-crypto": "^3.0.0-alpha.1",
+        "@arkecosystem/crypto": "^3.0.0-alpha.1",
+        "@oclif/command": "^1",
+        "@oclif/plugin-help": "^3",
         "@protokol/nft-base-crypto": "^1.0.0-beta.20",
         "@protokol/nft-exchange-crypto": "^1.0.0-beta.20",
-        "@oclif/command": "^1",
-        "@oclif/plugin-help": "^3"
+        "fs-extra": "^9.0.1"
     },
     "devDependencies": {
-        "typescript": "^3.8.3",
-        "ts-node": "^8"
+        "ts-node": "^8",
+        "typescript": "^3.8.3"
     },
     "oclif": {
         "commands": "./src/commands",

--- a/packages/nft-tx-tester/package.json
+++ b/packages/nft-tx-tester/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@protokol/nft-tx-tester",
-    "version": "1.0.0-beta.8",
+    "version": "1.0.0-beta.20",
     "description": "A simple command line utility to create and broadcast NFT transactions.",
     "license": "MIT",
     "homepage": "https://docs.protokol.com/nft/",
@@ -52,8 +52,8 @@
         "@arkecosystem/core-kernel": "^3.0.0-alpha.0",
         "@arkecosystem/crypto": "^3.0.0-alpha.0",
         "fs-extra": "^9.0.1",
-        "@protokol/nft-base-crypto": "^1.0.0-beta.13",
-        "@protokol/nft-exchange-crypto": "^1.0.0-beta.13",
+        "@protokol/nft-base-crypto": "^1.0.0-beta.20",
+        "@protokol/nft-exchange-crypto": "^1.0.0-beta.20",
         "@oclif/command": "^1",
         "@oclif/plugin-help": "^3"
     },

--- a/packages/nft-tx-tester/src/builders.ts
+++ b/packages/nft-tx-tester/src/builders.ts
@@ -1,20 +1,40 @@
 import * as MagistrateCrypto from "@arkecosystem/core-magistrate-crypto";
 import { Transactions } from "@arkecosystem/crypto";
 import * as NFTBaseCrypto from "@protokol/nft-base-crypto";
+import { ARKCrypto as ARKBaseNFTCrypto } from "@protokol/nft-base-crypto";
 import * as NFTExchangeCrypto from "@protokol/nft-exchange-crypto";
+import { ARKCrypto as ARKExchangeNFTCrypto } from "@protokol/nft-exchange-crypto";
 
 import { TransactionType } from "./enums";
 
 Transactions.TransactionRegistry.registerTransactionType(MagistrateCrypto.Transactions.EntityTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTBaseCrypto.Transactions.NFTRegisterCollectionTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTBaseCrypto.Transactions.NFTCreateTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTBaseCrypto.Transactions.NFTTransferTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTBaseCrypto.Transactions.NFTBurnTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTExchangeCrypto.Transactions.NFTAuctionTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTExchangeCrypto.Transactions.NFTAuctionCancelTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTExchangeCrypto.Transactions.NFTBidTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTExchangeCrypto.Transactions.NFTBidCancelTransaction);
-Transactions.TransactionRegistry.registerTransactionType(NFTExchangeCrypto.Transactions.NFTAcceptTradeTransaction);
+ARKBaseNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTBaseCrypto.Transactions.NFTRegisterCollectionTransaction,
+);
+ARKBaseNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTBaseCrypto.Transactions.NFTCreateTransaction,
+);
+ARKBaseNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTBaseCrypto.Transactions.NFTTransferTransaction,
+);
+ARKBaseNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTBaseCrypto.Transactions.NFTBurnTransaction,
+);
+ARKExchangeNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTExchangeCrypto.Transactions.NFTAuctionTransaction,
+);
+ARKExchangeNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTExchangeCrypto.Transactions.NFTAuctionCancelTransaction,
+);
+ARKExchangeNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTExchangeCrypto.Transactions.NFTBidTransaction,
+);
+ARKExchangeNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTExchangeCrypto.Transactions.NFTBidCancelTransaction,
+);
+ARKExchangeNFTCrypto.Transactions.TransactionRegistry.registerTransactionType(
+    NFTExchangeCrypto.Transactions.NFTAcceptTradeTransaction,
+);
 
 export const builders = {
     [TransactionType.Transfer]: { name: "Transfer", builder: Transactions.BuilderFactory.transfer },

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -6,6 +6,7 @@
 A Protokol module providing utils.
 
 # License
+
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 This work is licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-nc-sa/4.0/), under the following terms:

--- a/packages/utils/__tests__/unit/asserts/assert.test.ts
+++ b/packages/utils/__tests__/unit/asserts/assert.test.ts
@@ -1,4 +1,5 @@
 import "jest-extended";
+
 import { assert } from "../../../src/asserts";
 
 describe("Assertions", () => {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "@protokol/utils",
-	"description": "Protokol Utils",
-	"version": "1.0.0-beta.20",
+    "name": "@protokol/utils",
+    "description": "Protokol Utils",
+    "version": "1.0.0-beta.20",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"
@@ -18,39 +18,39 @@
         "nft",
         "blockchain"
     ],
-	"contributors": [
+    "contributors": [
         "Matej Lubej <matej@protokol.com>",
         "Kristjan Košič <kristjan@protokol.com>"
     ],
-	"license": "CC-BY-NC-SA-4.0",
-	"files": [
-		"/dist"
-	],
-	"main": "dist/index",
-	"types": "dist/index",
-	"scripts": {
-		"build": "yarn clean && tsc",
-		"build:watch": "yarn build -w",
-		"clean": "rimraf .coverage dist tmp",
-		"format": "yarn lint && yarn prettier",
-		"lint": "tslint -c tslint.json -p tslint.json 'src/**/*.ts' --fix",
-		"prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
+    "license": "CC-BY-NC-SA-4.0",
+    "files": [
+        "/dist"
+    ],
+    "main": "dist/index",
+    "types": "dist/index",
+    "scripts": {
+        "build": "yarn clean && tsc",
+        "build:watch": "yarn build -w",
+        "clean": "rimraf .coverage dist tmp",
+        "format": "yarn lint && yarn prettier",
+        "lint": "tslint -c tslint.json -p tslint.json 'src/**/*.ts' --fix",
+        "prettier": "prettier --write \"./*.{ts,js,json,md}\" \"./**/*.{ts,js,json,md}\"",
         "prepublishOnly": "yarn build"
     },
-	"devDependencies": {
-		"@types/prettier": "^2.0.0",
-		"@types/rimraf": "^3.0.0",
-		"@typeskrift/tsconfig": "^0.1.2",
-		"@typeskrift/tslint": "^0.1.5",
-		"cross-env": "^7.0.2",
-		"prettier": "^2.0.0",
-		"rimraf": "^3.0.2",
-		"tslint": "^6.1.0",
-		"typescript": "^3.8.3"
-	},
-	"engines": {
-		"node": ">=10.x"
-	},
+    "devDependencies": {
+        "@types/prettier": "^2.0.0",
+        "@types/rimraf": "^3.0.0",
+        "@typeskrift/tsconfig": "^0.1.2",
+        "@typeskrift/tslint": "^0.1.5",
+        "cross-env": "^7.0.2",
+        "prettier": "^2.0.0",
+        "rimraf": "^3.0.2",
+        "tslint": "^6.1.0",
+        "typescript": "^3.8.3"
+    },
+    "engines": {
+        "node": ">=10.x"
+    },
     "publishConfig": {
         "access": "public"
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@protokol/utils",
 	"description": "Protokol Utils",
-	"version": "1.0.0-beta.3",
+	"version": "1.0.0-beta.20",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"
@@ -19,7 +19,7 @@
         "blockchain"
     ],
 	"contributors": [
-        "Žan Kovač <zan@protokol.com",
+        "Matej Lubej <matej@protokol.com>",
         "Kristjan Košič <kristjan@protokol.com>"
     ],
 	"license": "CC-BY-NC-SA-4.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@protokol/utils",
     "description": "Protokol Utils",
-    "version": "1.0.0-beta.20",
+    "version": "1.0.0-beta.21",
     "homepage": "https://docs.protokol.com/nft/",
     "bugs": {
         "url": "https://github.com/protokol/nft-plugins/issues"

--- a/scripts/publish-beta.sh
+++ b/scripts/publish-beta.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+cd packages/utils && npm publish --tag beta && cd ../..
 cd packages/nft-base-crypto && npm publish --tag beta && cd ../..
 cd packages/nft-base-transactions && npm publish --tag beta && cd ../..
 cd packages/nft-base-api && npm publish --tag beta && cd ../..

--- a/scripts/publish-latest.sh
+++ b/scripts/publish-latest.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+cd packages/utils && npm publish --tag beta && cd ../..
 cd packages/nft-base-crypto && npm publish --tag latest && cd ../..
 cd packages/nft-base-transactions && npm publish --tag latest && cd ../..
 cd packages/nft-base-api && npm publish --tag latest && cd ../..


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Needed to manually up the packages version in core-nft, as otherwise node setup from sources doesn't work.  


- sync with the changes from the ark/core
- generic version bump for .beta.20 (still with .alfa.0 deps).
- manual bump of core packages to be the same as npm published number 3.0.0-alfa.1
- further adjustment to `exchange-crypto` to work with double export issue (temporary fix).

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

Switch to yarn 2 repo after this and changed staging install to go from npm. 

