### PR TITLE
chore(guardian-api): enable latest version for guardian config api

### DIFF
--- a/packages/guardian-api/__tests__/integration/handlers/configurations.test.ts
+++ b/packages/guardian-api/__tests__/integration/handlers/configurations.test.ts
@@ -2,8 +2,8 @@ import "@arkecosystem/core-test-framework/src/matchers";
 
 import { Contracts } from "@arkecosystem/core-kernel";
 import { ApiHelpers } from "@arkecosystem/core-test-framework/src";
+import latestVersion from "latest-version";
 
-// import latestVersion from "latest-version";
 import { setUp, tearDown } from "../__support__/setup";
 
 let app: Contracts.Kernel.Application;
@@ -24,9 +24,9 @@ describe("API - Configurations", () => {
 
             expect(response.data.data.package.name).toStrictEqual(require("../../../package.json").name);
             expect(response.data.data.package.currentVersion).toStrictEqual(require("../../../package.json").version);
-            // expect(response.data.data.package.latestVersion).toStrictEqual(
-            //     await latestVersion(require("../../../package.json").name),
-            // );
+            expect(response.data.data.package.latestVersion).toStrictEqual(
+                await latestVersion(require("../../../package.json").name),
+            );
             expect(response.data.data.crypto).toBeObject();
             expect(response.data.data.transactions).toBeObject();
         });

--- a/packages/guardian-api/__tests__/unit/controllers/configurations.test.ts
+++ b/packages/guardian-api/__tests__/unit/controllers/configurations.test.ts
@@ -6,8 +6,8 @@ import { Managers } from "@arkecosystem/crypto";
 import { configManager } from "@arkecosystem/crypto/src/managers";
 import { Defaults as CryptoDefaults } from "@protokol/guardian-crypto";
 import { Defaults as TransactionsDefaults } from "@protokol/guardian-transactions";
+import latestVersion from "latest-version";
 
-// import latestVersion from "latest-version";
 import { initApp, ItemResponse } from "../__support__";
 import { ConfigurationController } from "../../../src/controllers/configurations";
 
@@ -33,7 +33,7 @@ describe("Test configurations controller", () => {
             package: {
                 name: require("../../../package.json").name,
                 currentVersion: require("../../../package.json").version,
-                //latestVersion: await latestVersion(require("../../../package.json").name),
+                latestVersion: await latestVersion(require("../../../package.json").name),
             },
             crypto: CryptoDefaults,
             transactions: TransactionsDefaults,

--- a/packages/guardian-api/src/controllers/configurations.ts
+++ b/packages/guardian-api/src/controllers/configurations.ts
@@ -3,8 +3,8 @@ import { Container } from "@arkecosystem/core-kernel";
 import Hapi from "@hapi/hapi";
 import { Defaults as CryptoDefaults } from "@protokol/guardian-crypto";
 import { Defaults as TransactionDefaults } from "@protokol/guardian-transactions";
+import latestVersion from "latest-version";
 
-// import latestVersion from "latest-version";
 import { ConfigurationResource } from "../resources/configurations";
 
 const packageName = require("../../package.json").name;
@@ -17,7 +17,7 @@ export class ConfigurationController extends Controller {
             {
                 packageName,
                 currentVersion,
-                //latestVersion: await latestVersion(packageName),
+                latestVersion: await latestVersion(packageName),
                 crypto: CryptoDefaults,
                 transactions: TransactionDefaults,
             },

--- a/packages/guardian-api/src/resources/configurations.ts
+++ b/packages/guardian-api/src/resources/configurations.ts
@@ -26,7 +26,7 @@ export class ConfigurationResource implements Contracts.Resource {
             package: {
                 name: resource.packageName,
                 currentVersion: resource.currentVersion,
-                // latestVersion: resource.latestVersion,
+                latestVersion: resource.latestVersion,
             },
             crypto: resource.crypto,
             transactions: resource.transactions,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Enabled latest version in guardian API plugin. Closes https://github.com/protokol/nft-plugins/issues/144

### Why are these changes necessary?
To show the latest version in a guardian API response.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

