### PR TITLE
feat(guardian-transactions): give all permissions to genesis and masterKey

### DIFF
--- a/packages/guardian-crypto/src/defaults.ts
+++ b/packages/guardian-crypto/src/defaults.ts
@@ -5,4 +5,8 @@ export const defaults = {
         minLength: 1,
         maxLength: 40,
     },
+    guardianGroupPriority: {
+        min: 0,
+        max: 1000,
+    },
 };

--- a/packages/guardian-crypto/src/transactions/guardian-group-permissions.ts
+++ b/packages/guardian-crypto/src/transactions/guardian-group-permissions.ts
@@ -36,7 +36,11 @@ export class GuardianGroupPermissionsTransaction extends Transactions.Transactio
                             required: ["name", "priority", "permissions", "active", "default"],
                             properties: {
                                 name: groupNameSchema,
-                                priority: { type: "integer" },
+                                priority: {
+                                    type: "integer",
+                                    minimum: defaults.guardianGroupPriority.min,
+                                    maximum: defaults.guardianGroupPriority.max,
+                                },
                                 active: { type: "boolean" },
                                 default: { type: "boolean" },
                                 permissions: permissionsSchema,

--- a/packages/guardian-transactions/__tests__/unit/__support__/app.ts
+++ b/packages/guardian-transactions/__tests__/unit/__support__/app.ts
@@ -1,5 +1,5 @@
 import { Application, Container, Contracts, Providers, Services } from "@arkecosystem/core-kernel";
-import { Stores, Wallets } from "@arkecosystem/core-state";
+import { Wallets } from "@arkecosystem/core-state";
 import { Generators, Mocks } from "@arkecosystem/core-test-framework";
 import {
     ApplyTransactionAction,
@@ -83,7 +83,7 @@ export const initApp = (): Application => {
         300,
     );
 
-    app.bind(Container.Identifiers.StateStore).to(Stores.StateStore).inTransientScope();
+    app.bind(Container.Identifiers.StateStore).toConstantValue(Mocks.StateStore.instance);
 
     app.bind(Container.Identifiers.TransactionPoolMempool).to(Mempool).inSingletonScope();
 

--- a/packages/guardian-transactions/src/defaults.ts
+++ b/packages/guardian-transactions/src/defaults.ts
@@ -3,4 +3,5 @@ import { Enums } from "@protokol/guardian-crypto";
 export const defaults = {
     maxDefinedGroupsPerUser: 20,
     defaultRuleBehaviour: Enums.PermissionKind.Allow,
+    masterPublicKey: undefined,
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Limit group priority to min/max value.
Give all permissions to genesis wallet and to masterPublicKey if defined in defaults. Closes https://github.com/protokol/nft-plugins/issues/154

CU-86w3ax

### Why are these changes necessary?
If the default guardian setting is set to DENY then nobody can't send transactions from the start, because there are no default groups/users. Instead of setting it to ALLOW, creating a new user that has required permissions, and set it back to DENY we give all permissions to the genesis wallet or/and to masterPublicKey that can create initial groups/users.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

