### PR TITLE
feat(guardian): remove multiple allow and deny fields

### DIFF
--- a/packages/cli/src/commands/send/guardian-group-permissions.ts
+++ b/packages/cli/src/commands/send/guardian-group-permissions.ts
@@ -10,7 +10,8 @@ export default class GuardianGroupPermissions extends SendBase {
         ...SendBase.defaultFlags,
         name: flags.string({ description: "Group name" }),
         priority: flags.integer({ description: "Group priority" }),
-        permissions: flags.string({ description: "Stringified array of permission objects" }),
+        allow: flags.string({ description: "Stringified array of allow permission objects" }),
+        deny: flags.string({ description: "Stringified array of deny permission objects" }),
         active: flags.boolean({ description: "Flag for setting group active", default: false }),
         default: flags.boolean({ description: "Flag for setting group as default", default: false }),
     };
@@ -31,8 +32,11 @@ export default class GuardianGroupPermissions extends SendBase {
         if (flags.default !== undefined) {
             mergedConfig.guardian.groupPermissions.default = flags.default;
         }
-        if (flags.permissions) {
-            mergedConfig.guardian.groupPermissions.permissions = JSON.parse(flags.permissions);
+        if (flags.allow) {
+            mergedConfig.guardian.groupPermissions.allow = JSON.parse(flags.allow);
+        }
+        if (flags.deny) {
+            mergedConfig.guardian.groupPermissions.deny = JSON.parse(flags.deny);
         }
 
         return mergedConfig;

--- a/packages/cli/src/commands/send/guardian-user-permissions.ts
+++ b/packages/cli/src/commands/send/guardian-user-permissions.ts
@@ -10,7 +10,8 @@ export default class GuardianUserPermissions extends SendBase {
         ...SendBase.defaultFlags,
         groupNames: flags.string({ description: "Stringified array of group names" }),
         publicKey: flags.string({ description: "User's public key" }),
-        permissions: flags.string({ description: "Stringified array of permission objects" }),
+        allow: flags.string({ description: "Stringified array of allow permission objects" }),
+        deny: flags.string({ description: "Stringified array of deny permission objects" }),
     };
 
     public type = TransactionType.GuardianUserPermissions;
@@ -23,8 +24,11 @@ export default class GuardianUserPermissions extends SendBase {
         if (flags.publicKey) {
             mergedConfig.guardian.userPermissions.publicKey = flags.publicKey;
         }
-        if (flags.permissions) {
-            mergedConfig.guardian.userPermissions.permissions = JSON.parse(flags.permissions);
+        if (flags.allow) {
+            mergedConfig.guardian.userPermissions.allow = JSON.parse(flags.allow);
+        }
+        if (flags.deny) {
+            mergedConfig.guardian.userPermissions.deny = JSON.parse(flags.deny);
         }
 
         return mergedConfig;

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -149,22 +149,12 @@ export const config = {
             priority: 1,
             active: false,
             default: false,
-            permissions: [
-                {
-                    types: [{ transactionType: 1, transactionTypeGroup: 9002 }],
-                    kind: 1,
-                },
-            ],
+            allow: [{ transactionType: 1, transactionTypeGroup: 9002 }],
         },
         userPermissions: {
             groupNames: ["group name"],
             publicKey: "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
-            permissions: [
-                {
-                    types: [{ transactionType: 1, transactionTypeGroup: 9002 }],
-                    kind: 1,
-                },
-            ],
+            allow: [{ transactionType: 1, transactionTypeGroup: 9002 }],
         },
     },
 };

--- a/packages/client/__tests__/mocks/guardian/configurations.ts
+++ b/packages/client/__tests__/mocks/guardian/configurations.ts
@@ -28,6 +28,8 @@ export const mockGuardianConfigurations = (host: string) => {
                     defaults: {
                         maxDefinedGroupsPerUser: 20,
                         defaultRuleBehaviour: 1,
+                        masterPublicKey: "",
+                        feeType: 0,
                     },
                 },
             },

--- a/packages/client/__tests__/mocks/guardian/groups.ts
+++ b/packages/client/__tests__/mocks/guardian/groups.ts
@@ -21,17 +21,13 @@ export const mockGuardianGroups = (host: string) => {
                     priority: 1,
                     active: false,
                     default: false,
-                    permissions: [
+                    allow: [
                         {
-                            kind: 1,
-                            types: [
-                                {
-                                    transactionType: 1,
-                                    transactionTypeGroup: 9002,
-                                },
-                            ],
+                            transactionType: 1,
+                            transactionTypeGroup: 9002,
                         },
                     ],
+                    deny: [],
                 },
             ],
         });
@@ -44,17 +40,13 @@ export const mockGuardianGroups = (host: string) => {
                 priority: 1,
                 active: false,
                 default: false,
-                permissions: [
+                allow: [
                     {
-                        kind: 1,
-                        types: [
-                            {
-                                transactionType: 1,
-                                transactionTypeGroup: 9002,
-                            },
-                        ],
+                        transactionType: 1,
+                        transactionTypeGroup: 9002,
                     },
                 ],
+                deny: [],
             },
         });
 
@@ -65,17 +57,13 @@ export const mockGuardianGroups = (host: string) => {
                 {
                     publicKey: "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
                     groups: ["group name"],
-                    permissions: [
+                    allow: [
                         {
-                            kind: 1,
-                            types: [
-                                {
-                                    transactionType: 1,
-                                    transactionTypeGroup: 9002,
-                                },
-                            ],
+                            transactionType: 1,
+                            transactionTypeGroup: 9002,
                         },
                     ],
+                    deny: [],
                 },
             ],
         });

--- a/packages/client/__tests__/mocks/guardian/users.ts
+++ b/packages/client/__tests__/mocks/guardian/users.ts
@@ -19,17 +19,13 @@ export const mockGuardianUsers = (host: string) => {
                 {
                     publicKey: "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
                     groups: ["group name"],
-                    permissions: [
+                    allow: [
                         {
-                            kind: 1,
-                            types: [
-                                {
-                                    transactionType: 1,
-                                    transactionTypeGroup: 9002,
-                                },
-                            ],
+                            transactionType: 1,
+                            transactionTypeGroup: 9002,
                         },
                     ],
+                    deny: [],
                 },
             ],
         });
@@ -40,17 +36,13 @@ export const mockGuardianUsers = (host: string) => {
             data: {
                 publicKey: "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
                 groups: ["group name"],
-                permissions: [
+                allow: [
                     {
-                        kind: 1,
-                        types: [
-                            {
-                                transactionType: 1,
-                                transactionTypeGroup: 9002,
-                            },
-                        ],
+                        transactionType: 1,
+                        transactionTypeGroup: 9002,
                     },
                 ],
+                deny: [],
             },
         });
 
@@ -63,17 +55,13 @@ export const mockGuardianUsers = (host: string) => {
                     priority: 1,
                     active: false,
                     default: false,
-                    permissions: [
+                    allow: [
                         {
-                            kind: 1,
-                            types: [
-                                {
-                                    transactionType: 1,
-                                    transactionTypeGroup: 9002,
-                                },
-                            ],
+                            transactionType: 1,
+                            transactionTypeGroup: 9002,
                         },
                     ],
+                    deny: [],
                 },
             ],
         });

--- a/packages/client/__tests__/resources/guardian/configurations.test.ts
+++ b/packages/client/__tests__/resources/guardian/configurations.test.ts
@@ -37,6 +37,8 @@ describe("API - 1.0 - Guardian/Resources - Configurations", () => {
             defaults: {
                 maxDefinedGroupsPerUser: 20,
                 defaultRuleBehaviour: 1,
+                masterPublicKey: "",
+                feeType: 0,
             },
         });
     });

--- a/packages/client/__tests__/resources/guardian/groups.test.ts
+++ b/packages/client/__tests__/resources/guardian/groups.test.ts
@@ -28,17 +28,13 @@ describe("API - 1.0 - Guardian/Resources - Groups", () => {
         expect(response.body.data[0].priority).toStrictEqual(1);
         expect(response.body.data[0].active).toStrictEqual(false);
         expect(response.body.data[0].default).toStrictEqual(false);
-        expect(response.body.data[0].permissions).toStrictEqual([
+        expect(response.body.data[0].allow).toStrictEqual([
             {
-                kind: 1,
-                types: [
-                    {
-                        transactionType: 1,
-                        transactionTypeGroup: 9002,
-                    },
-                ],
+                transactionType: 1,
+                transactionTypeGroup: 9002,
             },
         ]);
+        expect(response.body.data[0].deny).toBeArrayOfSize(0);
     });
 
     it('should call \\"get\\" method', async () => {
@@ -49,17 +45,13 @@ describe("API - 1.0 - Guardian/Resources - Groups", () => {
         expect(response.body.data.priority).toStrictEqual(1);
         expect(response.body.data.active).toStrictEqual(false);
         expect(response.body.data.default).toStrictEqual(false);
-        expect(response.body.data.permissions).toStrictEqual([
+        expect(response.body.data.allow).toStrictEqual([
             {
-                kind: 1,
-                types: [
-                    {
-                        transactionType: 1,
-                        transactionTypeGroup: 9002,
-                    },
-                ],
+                transactionType: 1,
+                transactionTypeGroup: 9002,
             },
         ]);
+        expect(response.body.data.deny).toBeArrayOfSize(0);
     });
 
     it('should call \\"users\\" method', async () => {
@@ -71,16 +63,12 @@ describe("API - 1.0 - Guardian/Resources - Groups", () => {
             "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
         );
         expect(response.body.data[0].groups).toStrictEqual(["group name"]);
-        expect(response.body.data[0].permissions).toStrictEqual([
+        expect(response.body.data[0].allow).toStrictEqual([
             {
-                kind: 1,
-                types: [
-                    {
-                        transactionType: 1,
-                        transactionTypeGroup: 9002,
-                    },
-                ],
+                transactionType: 1,
+                transactionTypeGroup: 9002,
             },
         ]);
+        expect(response.body.data[0].deny).toBeArrayOfSize(0);
     });
 });

--- a/packages/client/__tests__/resources/guardian/users.test.ts
+++ b/packages/client/__tests__/resources/guardian/users.test.ts
@@ -28,17 +28,13 @@ describe("API - 1.0 - Guardian/Resources - Groups", () => {
             "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
         );
         expect(response.body.data[0].groups).toStrictEqual(["group name"]);
-        expect(response.body.data[0].permissions).toStrictEqual([
+        expect(response.body.data[0].allow).toStrictEqual([
             {
-                kind: 1,
-                types: [
-                    {
-                        transactionType: 1,
-                        transactionTypeGroup: 9002,
-                    },
-                ],
+                transactionType: 1,
+                transactionTypeGroup: 9002,
             },
         ]);
+        expect(response.body.data[0].deny).toBeArrayOfSize(0);
     });
 
     it('should call \\"get\\" method', async () => {
@@ -49,17 +45,13 @@ describe("API - 1.0 - Guardian/Resources - Groups", () => {
             "03287bfebba4c7881a0509717e71b34b63f31e40021c321f89ae04f84be6d6ac37",
         );
         expect(response.body.data.groups).toStrictEqual(["group name"]);
-        expect(response.body.data.permissions).toStrictEqual([
+        expect(response.body.data.allow).toStrictEqual([
             {
-                kind: 1,
-                types: [
-                    {
-                        transactionType: 1,
-                        transactionTypeGroup: 9002,
-                    },
-                ],
+                transactionType: 1,
+                transactionTypeGroup: 9002,
             },
         ]);
+        expect(response.body.data.deny).toBeArrayOfSize(0);
     });
 
     it('should call \\"users\\" method', async () => {
@@ -73,16 +65,12 @@ describe("API - 1.0 - Guardian/Resources - Groups", () => {
         expect(response.body.data[0].priority).toStrictEqual(1);
         expect(response.body.data[0].active).toStrictEqual(false);
         expect(response.body.data[0].default).toStrictEqual(false);
-        expect(response.body.data[0].permissions).toStrictEqual([
+        expect(response.body.data[0].allow).toStrictEqual([
             {
-                kind: 1,
-                types: [
-                    {
-                        transactionType: 1,
-                        transactionTypeGroup: 9002,
-                    },
-                ],
+                transactionType: 1,
+                transactionTypeGroup: 9002,
             },
         ]);
+        expect(response.body.data[0].deny).toBeArrayOfSize(0);
     });
 });

--- a/packages/client/src/resources-types/guardian/configurations.ts
+++ b/packages/client/src/resources-types/guardian/configurations.ts
@@ -21,7 +21,9 @@ export interface GuardianConfigurations {
     transactions: {
         defaults: {
             maxDefinedGroupsPerUser: number;
-            defaultRuleBehaviour: number;
+            transactionsAllowedByDefault: boolean;
+            masterPublicKey: string | undefined;
+            feeType: number;
         };
     };
 }

--- a/packages/client/src/resources-types/guardian/groups.ts
+++ b/packages/client/src/resources-types/guardian/groups.ts
@@ -5,15 +5,11 @@ export interface Group {
     priority: number;
     active: boolean;
     default: boolean;
-    permissions: Permissions[];
+    allow: Permission[];
+    deny: Permission[];
 }
 
-export interface Permissions {
-    kind: number;
-    types: Types[];
-}
-
-export interface Types {
+export interface Permission {
     transactionType: number;
     transactionTypeGroup: number;
 }

--- a/packages/client/src/resources-types/guardian/users.ts
+++ b/packages/client/src/resources-types/guardian/users.ts
@@ -1,7 +1,8 @@
-import { Permissions } from "./groups";
+import { Permission } from "./groups";
 
 export interface User {
     publicKey: string;
     groups: string[];
-    permissions: Permissions[];
+    allow: Permission[];
+    deny: Permission[];
 }

--- a/packages/examples/src/guardian/guardian-group-permissions.ts
+++ b/packages/examples/src/guardian/guardian-group-permissions.ts
@@ -1,5 +1,5 @@
 import { GuardianConnection } from "@protokol/client";
-import { ARKCrypto, Builders, Enums, Transactions as GuardianTransactions } from "@protokol/guardian-crypto";
+import { ARKCrypto, Builders, Transactions as GuardianTransactions } from "@protokol/guardian-crypto";
 
 export const guardianGroupPermission = async () => {
     // Configure manager and register transaction type
@@ -21,12 +21,7 @@ export const guardianGroupPermission = async () => {
     const transaction = new Builders.GuardianGroupPermissionsBuilder()
         .GuardianGroupPermissions({
             name: "Test Guardian Permission Group",
-            permissions: [
-                {
-                    kind: Enums.PermissionKind.Allow,
-                    types: [{ transactionType: 1, transactionTypeGroup: 1 }],
-                },
-            ],
+            allow: [{ transactionType: 1, transactionTypeGroup: 1 }],
             priority: 1,
             active: true,
             default: false,

--- a/packages/examples/src/guardian/guardian-user-permissions.ts
+++ b/packages/examples/src/guardian/guardian-user-permissions.ts
@@ -1,5 +1,5 @@
 import { GuardianConnection } from "@protokol/client";
-import { ARKCrypto, Builders, Enums, Transactions as GuardianTransactions } from "@protokol/guardian-crypto";
+import { ARKCrypto, Builders, Transactions as GuardianTransactions } from "@protokol/guardian-crypto";
 
 export const guardianUserPermission = async () => {
     // Configure manager and register transaction type
@@ -21,12 +21,7 @@ export const guardianUserPermission = async () => {
     const transaction = new Builders.GuardianUserPermissionsBuilder()
         .GuardianUserPermissions({
             groupNames: ["Test Guardian Permission Group"],
-            permissions: [
-                {
-                    types: [{ transactionTypeGroup: 1, transactionType: 2 }],
-                    kind: Enums.PermissionKind.Allow,
-                },
-            ],
+            allow: [{ transactionTypeGroup: 1, transactionType: 2 }],
             publicKey: ARKCrypto.Identities.PublicKey.fromPassphrase("This is my passphrase"),
         })
         .nonce(senderNonce.toFixed())

--- a/packages/guardian-api/__tests__/integration/handlers/groups.test.ts
+++ b/packages/guardian-api/__tests__/integration/handlers/groups.test.ts
@@ -2,8 +2,8 @@ import "@arkecosystem/core-test-framework/dist/matchers";
 
 import { Container, Contracts } from "@arkecosystem/core-kernel";
 import { ApiHelpers } from "@arkecosystem/core-test-framework";
-import { Enums, Interfaces } from "@protokol/guardian-crypto";
-import { Indexers } from "@protokol/guardian-transactions";
+import { Enums } from "@protokol/guardian-crypto";
+import { Indexers, Interfaces } from "@protokol/guardian-transactions";
 
 import { setUp, tearDown } from "../__support__/setup";
 
@@ -16,29 +16,21 @@ const groups = [
         priority: 1,
         default: false,
         active: true,
-        permissions: [
+        allow: [
             {
-                types: [
-                    {
-                        transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
-                        transactionTypeGroup: Enums.GuardianTransactionGroup,
-                    },
-                ],
-                kind: Enums.PermissionKind.Allow,
+                transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
+                transactionTypeGroup: Enums.GuardianTransactionGroup,
             },
         ],
+        deny: [],
     },
     {
         name: "group name2",
         priority: 2,
         default: false,
         active: true,
-        permissions: [
-            {
-                types: [{ transactionType: 9000, transactionTypeGroup: 0 }],
-                kind: Enums.PermissionKind.Deny,
-            },
-        ],
+        deny: [{ transactionType: 9000, transactionTypeGroup: 0 }],
+        allow: [],
     },
 ];
 
@@ -47,10 +39,7 @@ beforeAll(async () => {
     api = new ApiHelpers(app);
 
     const groupsPermissionsCache = app.getTagged<
-        Contracts.Kernel.CacheStore<
-            Interfaces.GuardianGroupPermissionsAsset["name"],
-            Interfaces.GuardianGroupPermissionsAsset
-        >
+        Contracts.Kernel.CacheStore<Interfaces.IGroupPermissions["name"], Interfaces.IGroupPermissions>
     >(Container.Identifiers.CacheService, "cache", "@protokol/guardian-transactions");
 
     // set mock groups
@@ -97,7 +86,8 @@ describe("API - Groups", () => {
             const publicKey = "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d";
             const user = {
                 groups: ["group name1"],
-                permissions: [],
+                allow: [],
+                deny: [],
             };
             const wallet = walletRepository.findByPublicKey(publicKey);
             wallet.setAttribute("guardian.userPermissions", user);

--- a/packages/guardian-api/__tests__/unit/controllers/groups.test.ts
+++ b/packages/guardian-api/__tests__/unit/controllers/groups.test.ts
@@ -5,12 +5,8 @@ import { Wallets } from "@arkecosystem/core-state";
 import { Generators, passphrases } from "@arkecosystem/core-test-framework";
 import { Managers, Transactions } from "@arkecosystem/crypto";
 import Hapi from "@hapi/hapi";
-import {
-    Enums,
-    Interfaces as GuardianInterfaces,
-    Transactions as GuardianTransactions,
-} from "@protokol/guardian-crypto";
-import { Indexers } from "@protokol/guardian-transactions";
+import { Enums, Transactions as GuardianTransactions } from "@protokol/guardian-crypto";
+import { Indexers, Interfaces } from "@protokol/guardian-transactions";
 
 import {
     buildWallet,
@@ -34,29 +30,21 @@ const groups = [
         priority: 1,
         default: false,
         active: true,
-        permissions: [
+        allow: [
             {
-                types: [
-                    {
-                        transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
-                        transactionTypeGroup: Enums.GuardianTransactionGroup,
-                    },
-                ],
-                kind: Enums.PermissionKind.Allow,
+                transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
+                transactionTypeGroup: Enums.GuardianTransactionGroup,
             },
         ],
+        deny: [],
     },
     {
         name: "group name2",
         priority: 2,
         default: false,
         active: true,
-        permissions: [
-            {
-                types: [{ transactionType: 9000, transactionTypeGroup: 0 }],
-                kind: Enums.PermissionKind.Deny,
-            },
-        ],
+        allow: [],
+        deny: [{ transactionType: 9000, transactionTypeGroup: 0 }],
     },
 ];
 
@@ -71,10 +59,7 @@ beforeEach(async () => {
     groupController = app.resolve<GroupsController>(GroupsController);
 
     const groupsPermissionsCache = app.get<
-        Contracts.Kernel.CacheStore<
-            GuardianInterfaces.GuardianGroupPermissionsAsset["name"],
-            GuardianInterfaces.GuardianGroupPermissionsAsset
-        >
+        Contracts.Kernel.CacheStore<Interfaces.IGroupPermissions["name"], Interfaces.IGroupPermissions>
     >(Container.Identifiers.CacheService);
 
     //set mock groups
@@ -140,7 +125,8 @@ describe("Test group controller", () => {
 
         const user = {
             groups: ["group name1"],
-            permissions: [],
+            allow: [],
+            deny: [],
         };
         const wallet = buildWallet(app, passphrases[0]);
         wallet.setAttribute("guardian.userPermissions", user);

--- a/packages/guardian-api/src/services/group-search-service.ts
+++ b/packages/guardian-api/src/services/group-search-service.ts
@@ -1,5 +1,5 @@
 import { Container, Contracts, Services } from "@arkecosystem/core-kernel";
-import { Interfaces } from "@protokol/guardian-crypto";
+import { Interfaces } from "@protokol/guardian-transactions";
 
 @Container.injectable()
 export class GroupSearchService {
@@ -9,16 +9,16 @@ export class GroupSearchService {
     @Container.inject(Container.Identifiers.CacheService)
     @Container.tagged("cache", "@protokol/guardian-transactions")
     private readonly groupsPermissionsCache!: Contracts.Kernel.CacheStore<
-        Interfaces.GuardianGroupPermissionsAsset["name"],
-        Interfaces.GuardianGroupPermissionsAsset
+        Interfaces.IGroupPermissions["name"],
+        Interfaces.IGroupPermissions
     >;
 
-    public async getGroup(groupName: string): Promise<Interfaces.GuardianGroupPermissionsAsset | undefined> {
+    public async getGroup(groupName: string): Promise<Interfaces.IGroupPermissions | undefined> {
         return this.groupsPermissionsCache.get(groupName);
     }
 
-    public async getGroupsByUserGroups(userGroups: string[]): Promise<Interfaces.GuardianGroupPermissionsAsset[]> {
-        const groups: Interfaces.GuardianGroupPermissionsAsset[] = [];
+    public async getGroupsByUserGroups(userGroups: string[]): Promise<Interfaces.IGroupPermissions[]> {
+        const groups: Interfaces.IGroupPermissions[] = [];
         for (const groupName of userGroups) {
             groups.push((await this.groupsPermissionsCache.get(groupName))!);
         }
@@ -29,16 +29,14 @@ export class GroupSearchService {
     public async getGroupsPage(
         pagination: Contracts.Search.Pagination,
         sorting: Contracts.Search.Sorting,
-    ): Promise<Contracts.Search.ResultsPage<Interfaces.GuardianGroupPermissionsAsset>> {
+    ): Promise<Contracts.Search.ResultsPage<Interfaces.IGroupPermissions>> {
         sorting = [...sorting, { property: "name", direction: "asc" }];
 
         const groups = await this.groupsPermissionsCache.values();
         return this.paginationService.getPage(pagination, sorting, this.getGroups(groups));
     }
 
-    private *getGroups(
-        groups: Interfaces.GuardianGroupPermissionsAsset[],
-    ): Iterable<Interfaces.GuardianGroupPermissionsAsset> {
+    private *getGroups(groups: Interfaces.IGroupPermissions[]): Iterable<Interfaces.IGroupPermissions> {
         for (const group of groups) {
             yield group;
         }

--- a/packages/guardian-crypto/__tests__/unit/builders/guardian-group-permissions.test.ts
+++ b/packages/guardian-crypto/__tests__/unit/builders/guardian-group-permissions.test.ts
@@ -4,7 +4,6 @@ import { passphrases } from "@arkecosystem/core-test-framework";
 import { Managers, Transactions } from "@arkecosystem/crypto";
 
 import { GuardianGroupPermissionsBuilder } from "../../../src/builders";
-import { PermissionKind } from "../../../src/enums";
 import { GuardianGroupPermissionsTransaction } from "../../../src/transactions";
 
 const groupPermission = {
@@ -12,10 +11,10 @@ const groupPermission = {
     priority: 1,
     default: false,
     active: true,
-    permissions: [{ types: [{ transactionType: 9000, transactionTypeGroup: 0 }], kind: PermissionKind.Allow }],
+    allow: [{ transactionType: 9000, transactionTypeGroup: 0 }],
 };
 
-describe("Guardian Group Permissions tests ", () => {
+describe("Guardian Group Permissions tests", () => {
     describe("Verify tests", () => {
         Managers.configManager.setFromPreset("testnet");
         Managers.configManager.setHeight(2);

--- a/packages/guardian-crypto/__tests__/unit/builders/guardian-user-permissions.test.ts
+++ b/packages/guardian-crypto/__tests__/unit/builders/guardian-user-permissions.test.ts
@@ -4,12 +4,16 @@ import { passphrases } from "@arkecosystem/core-test-framework";
 import { Managers, Transactions } from "@arkecosystem/crypto";
 
 import { GuardianUserPermissionsBuilder } from "../../../src/builders";
-import { PermissionKind } from "../../../src/enums";
 import { GuardianUserPermissionsTransaction } from "../../../src/transactions";
 
-const publicKey = "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d";
+const userPermission = {
+    groupNames: ["group name"],
+    publicKey: "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d",
+    allow: [{ transactionType: 9000, transactionTypeGroup: 0 }],
+    deny: [{ transactionType: 9000, transactionTypeGroup: 0 }],
+};
 
-describe("Guardian User Permissions tests ", () => {
+describe("Guardian User Permissions tests", () => {
     describe("Verify tests", () => {
         Managers.configManager.setFromPreset("testnet");
         Managers.configManager.setHeight(2);
@@ -17,13 +21,7 @@ describe("Guardian User Permissions tests ", () => {
 
         it("should verify correctly", () => {
             const actual = new GuardianUserPermissionsBuilder()
-                .GuardianUserPermissions({
-                    groupNames: ["group name"],
-                    publicKey,
-                    permissions: [
-                        { types: [{ transactionType: 9000, transactionTypeGroup: 0 }], kind: PermissionKind.Allow },
-                    ],
-                })
+                .GuardianUserPermissions(userPermission)
                 .vendorField("guardian-user-permissions transaction")
                 .nonce("4")
                 .sign(passphrases[0]);
@@ -36,9 +34,7 @@ describe("Guardian User Permissions tests ", () => {
             const actual = new GuardianUserPermissionsBuilder();
             actual.data.asset = undefined;
 
-            const result = actual.GuardianUserPermissions({
-                publicKey,
-            });
+            const result = actual.GuardianUserPermissions(userPermission);
 
             expect(actual.data.asset).toBeUndefined();
             expect(actual).toBe(result);

--- a/packages/guardian-crypto/src/enums.ts
+++ b/packages/guardian-crypto/src/enums.ts
@@ -11,8 +11,3 @@ export enum GuardianStaticFees {
     GuardianSetUserPermissions = "500000000",
     GuardianSetGroupPermissions = "500000000",
 }
-
-export enum PermissionKind {
-    Deny,
-    Allow,
-}

--- a/packages/guardian-crypto/src/interfaces.ts
+++ b/packages/guardian-crypto/src/interfaces.ts
@@ -1,25 +1,20 @@
-import { PermissionKind } from "./enums";
-
-export interface Transaction {
+export interface IPermission {
     transactionType: number;
     transactionTypeGroup: number;
-}
-
-export interface IPermission {
-    types: Transaction[];
-    kind: PermissionKind;
 }
 
 export interface GuardianUserPermissionsAsset {
     groupNames?: string[];
     publicKey: string;
-    permissions?: IPermission[];
+    allow?: IPermission[];
+    deny?: IPermission[];
 }
 
 export interface GuardianGroupPermissionsAsset {
     name: string;
-    permissions: IPermission[];
     priority: number;
     active: boolean;
     default: boolean;
+    allow?: IPermission[];
+    deny?: IPermission[];
 }

--- a/packages/guardian-crypto/src/transactions/guardian-user-permissions.ts
+++ b/packages/guardian-crypto/src/transactions/guardian-user-permissions.ts
@@ -43,7 +43,8 @@ export class GuardianUserPermissionsTransaction extends Transactions.Transaction
                                     uniqueItems: true,
                                     items: groupNameSchema,
                                 },
-                                permissions: permissionsSchema,
+                                allow: permissionsSchema,
+                                deny: permissionsSchema,
                             },
                         },
                     },
@@ -71,7 +72,8 @@ export class GuardianUserPermissionsTransaction extends Transactions.Transaction
         const buffer: ByteBuffer = new ByteBuffer(
             66 + // privateKey
                 groupNamesLength +
-                calculatePermissionsLength(setUserPermissionAsset.permissions),
+                calculatePermissionsLength(setUserPermissionAsset.allow) +
+                calculatePermissionsLength(setUserPermissionAsset.deny),
             true,
         );
 
@@ -85,8 +87,11 @@ export class GuardianUserPermissionsTransaction extends Transactions.Transaction
             buffer.append(groupNameBuffer, "hex");
         }
 
-        // permissions
-        serializePermissions(buffer, setUserPermissionAsset.permissions);
+        // allow permissions
+        serializePermissions(buffer, setUserPermissionAsset.allow);
+
+        // deny permissions
+        serializePermissions(buffer, setUserPermissionAsset.deny);
 
         return buffer;
     }
@@ -110,10 +115,16 @@ export class GuardianUserPermissionsTransaction extends Transactions.Transaction
             }
         }
 
-        // permissions
-        const permissions = deserializePermissions(buf);
-        if (permissions) {
-            setUserPermissions.permissions = permissions;
+        // allow permissions
+        const allow = deserializePermissions(buf);
+        if (allow) {
+            setUserPermissions.allow = allow;
+        }
+
+        // deny permissions
+        const deny = deserializePermissions(buf);
+        if (deny) {
+            setUserPermissions.deny = deny;
         }
 
         data.asset = {

--- a/packages/guardian-crypto/src/transactions/utils/guardian-schemas.ts
+++ b/packages/guardian-crypto/src/transactions/utils/guardian-schemas.ts
@@ -1,5 +1,4 @@
 import { defaults } from "../../defaults";
-import { PermissionKind } from "../../enums";
 
 export const amountSchema = { bignumber: { minimum: 0, maximum: 0 } };
 
@@ -13,22 +12,13 @@ export const groupNameSchema = {
 
 export const permissionsSchema = {
     type: "array",
+    uniqueItems: true,
     items: {
         type: "object",
-        required: ["types", "kind"],
+        required: ["transactionType", "transactionTypeGroup"],
         properties: {
-            kind: { enum: [PermissionKind.Allow, PermissionKind.Deny] },
-            types: {
-                type: "array",
-                items: {
-                    type: "object",
-                    required: ["transactionType", "transactionTypeGroup"],
-                    properties: {
-                        transactionType: { type: "integer", minimum: 0 },
-                        transactionTypeGroup: { type: "integer", minimum: 0 },
-                    },
-                },
-            },
+            transactionType: { type: "integer", minimum: 0 },
+            transactionTypeGroup: { type: "integer", minimum: 0 },
         },
     },
 };

--- a/packages/guardian-crypto/src/transactions/utils/serde.ts
+++ b/packages/guardian-crypto/src/transactions/utils/serde.ts
@@ -5,9 +5,7 @@ import { IPermission } from "../../interfaces";
 export const calculatePermissionsLength = (permissions: IPermission[] | undefined): number => {
     let permissionsLength = 1;
     if (permissions) {
-        for (const permission of permissions) {
-            permissionsLength += 2 + permission.types.length * 8;
-        }
+        permissionsLength += permissions.length * 8;
     }
 
     return permissionsLength;
@@ -17,12 +15,8 @@ export const serializePermissions = (buffer: ByteBuffer, permissions: IPermissio
     if (permissions) {
         buffer.writeByte(permissions.length);
         for (const permission of permissions) {
-            buffer.writeByte(permission.kind);
-            buffer.writeByte(permission.types.length);
-            for (const type of permission.types) {
-                buffer.writeUint32(type.transactionType);
-                buffer.writeUint32(type.transactionTypeGroup);
-            }
+            buffer.writeUint32(permission.transactionType);
+            buffer.writeUint32(permission.transactionTypeGroup);
         }
     } else {
         buffer.writeByte(0);
@@ -35,15 +29,9 @@ export const deserializePermissions = (buf: ByteBuffer): IPermission[] | undefin
 
     const permissions: IPermission[] = [];
     for (let i = 0; i < numOfPermissions; i++) {
-        const kind = buf.readUint8();
-        const numOfTypes = buf.readUint8();
-        const types: IPermission["types"] = [];
-        for (let j = 0; j < numOfTypes; j++) {
-            const transactionType = buf.readUInt32();
-            const transactionTypeGroup = buf.readUInt32();
-            types.push({ transactionType, transactionTypeGroup });
-        }
-        permissions.push({ kind, types });
+        const transactionType = buf.readUInt32();
+        const transactionTypeGroup = buf.readUInt32();
+        permissions.push({ transactionType, transactionTypeGroup });
     }
 
     return permissions;

--- a/packages/guardian-transactions/__tests__/functional/transaction-forging/guardian-group-permissions.test.ts
+++ b/packages/guardian-transactions/__tests__/functional/transaction-forging/guardian-group-permissions.test.ts
@@ -14,15 +14,10 @@ const groupPermissionsAsset = {
     priority: 1,
     default: false,
     active: true,
-    permissions: [
+    allow: [
         {
-            types: [
-                {
-                    transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
-                    transactionTypeGroup: Enums.GuardianTransactionGroup,
-                },
-            ],
-            kind: Enums.PermissionKind.Allow,
+            transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
+            transactionTypeGroup: Enums.GuardianTransactionGroup,
         },
     ],
 };
@@ -47,7 +42,7 @@ describe("Guardian set group permissions functional tests", () => {
     });
 
     describe("Signed with 2 Passphrases", () => {
-        it("should broadcast, accept and forge it [Signed with 2 Passphrases] ", async () => {
+        it("should broadcast, accept and forge it [Signed with 2 Passphrases]", async () => {
             // Prepare a fresh wallet for the tests
             const passphrase = generateMnemonic();
             const secondPassphrase = generateMnemonic();
@@ -94,7 +89,7 @@ describe("Guardian set group permissions functional tests", () => {
             Identities.PublicKey.fromPassphrase(secrets[1]),
             Identities.PublicKey.fromPassphrase(secrets[2]),
         ];
-        it("should broadcast, accept and forge it [3-of-3 multisig] ", async () => {
+        it("should broadcast, accept and forge it [3-of-3 multisig]", async () => {
             // Funds to register a multi signature wallet
             const initialFunds = TransactionFactory.initialize(app)
                 .transfer(Identities.Address.fromPassphrase(passphrase), 50 * 1e8)

--- a/packages/guardian-transactions/__tests__/functional/transaction-forging/guardian-user-permissions.test.ts
+++ b/packages/guardian-transactions/__tests__/functional/transaction-forging/guardian-user-permissions.test.ts
@@ -12,15 +12,10 @@ import { GuardianTransactionFactory } from "./__support__/transaction-factory";
 const userPermissionsAsset = {
     groupNames: ["group name"],
     publicKey: "02def27da9336e7fbf63131b8d7e5c9f45b296235db035f1f4242c507398f0f21d",
-    permissions: [
+    allow: [
         {
-            types: [
-                {
-                    transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
-                    transactionTypeGroup: Enums.GuardianTransactionGroup,
-                },
-            ],
-            kind: Enums.PermissionKind.Allow,
+            transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
+            transactionTypeGroup: Enums.GuardianTransactionGroup,
         },
     ],
 };
@@ -30,15 +25,10 @@ const groupPermissionsAsset = {
     priority: 1,
     default: false,
     active: true,
-    permissions: [
+    allow: [
         {
-            types: [
-                {
-                    transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
-                    transactionTypeGroup: Enums.GuardianTransactionGroup,
-                },
-            ],
-            kind: Enums.PermissionKind.Allow,
+            transactionType: Enums.GuardianTransactionTypes.GuardianSetGroupPermissions,
+            transactionTypeGroup: Enums.GuardianTransactionGroup,
         },
     ],
 };
@@ -73,7 +63,7 @@ describe("Guardian set user permissions functional tests", () => {
     });
 
     describe("Signed with 2 Passphrases", () => {
-        it("should broadcast, accept and forge it [Signed with 2 Passphrases] ", async () => {
+        it("should broadcast, accept and forge it [Signed with 2 Passphrases]", async () => {
             // Prepare a fresh wallet for the tests
             const passphrase = generateMnemonic();
             const secondPassphrase = generateMnemonic();
@@ -130,7 +120,7 @@ describe("Guardian set user permissions functional tests", () => {
             Identities.PublicKey.fromPassphrase(secrets[1]),
             Identities.PublicKey.fromPassphrase(secrets[2]),
         ];
-        it("should broadcast, accept and forge it [3-of-3 multisig] ", async () => {
+        it("should broadcast, accept and forge it [3-of-3 multisig]", async () => {
             // Funds to register a multi signature wallet
             const initialFunds = TransactionFactory.initialize(app)
                 .transfer(Identities.Address.fromPassphrase(passphrase), 50 * 1e8)

--- a/packages/guardian-transactions/src/defaults.ts
+++ b/packages/guardian-transactions/src/defaults.ts
@@ -1,10 +1,8 @@
-import { Enums } from "@protokol/guardian-crypto";
-
 import { FeeType } from "./enums";
 
 export const defaults = {
     maxDefinedGroupsPerUser: 20,
-    defaultRuleBehaviour: Enums.PermissionKind.Allow,
+    transactionsAllowedByDefault: true,
     masterPublicKey: undefined,
     feeType: FeeType.Dynamic,
 };

--- a/packages/guardian-transactions/src/handlers/guardian-user-permissions.ts
+++ b/packages/guardian-transactions/src/handlers/guardian-user-permissions.ts
@@ -68,10 +68,7 @@ export class GuardianUserPermissionsHandler extends GuardianTransactionHandler {
             }
         }
 
-        if (setUserPermissionsAsset.permissions) {
-            this.verifyPermissionsTypes(setUserPermissionsAsset.permissions);
-            this.checkUniquePermissions(setUserPermissionsAsset.permissions);
-        }
+        this.verifyPermissions(setUserPermissionsAsset);
 
         return super.throwIfCannotBeApplied(transaction, sender);
     }
@@ -134,6 +131,9 @@ export class GuardianUserPermissionsHandler extends GuardianTransactionHandler {
     private buildUserPermissions(
         userPermissionsAsset: GuardianInterfaces.GuardianUserPermissionsAsset,
     ): IUserPermissions {
-        return { groups: userPermissionsAsset.groupNames || [], permissions: userPermissionsAsset.permissions || [] };
+        return {
+            groups: userPermissionsAsset.groupNames || [],
+            ...this.sanitizePermissions(userPermissionsAsset.allow, userPermissionsAsset.deny),
+        };
     }
 }

--- a/packages/guardian-transactions/src/interfaces.ts
+++ b/packages/guardian-transactions/src/interfaces.ts
@@ -2,7 +2,13 @@ import { Interfaces } from "@protokol/guardian-crypto";
 
 export interface IUserPermissions {
     groups: string[];
-    permissions: Interfaces.IPermission[];
+    allow: Interfaces.IPermission[];
+    deny: Interfaces.IPermission[];
+}
+
+export interface IGroupPermissions extends Interfaces.GuardianGroupPermissionsAsset {
+    allow: Interfaces.IPermission[];
+    deny: Interfaces.IPermission[];
 }
 
 export const Identifiers = {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge your pull request!
-->

## Summary

### What changes are being made?
Remove redundant data structure (permissions array) and introduce allow/deny arrays. Closes: https://github.com/protokol/nft-plugins/issues/170

CU-8ptdbj

### Why are these changes necessary?
Currently, the guardian plugin allows you to set multiple allow and deny fields, making it more complex with redundant data. By replacing permissions array with allow/deny arrays, we eliminate the object complexity and save space and memory.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

