### PR TITLE
feat(guardian-api): improve forbidden error handling

### DIFF
--- a/packages/guardian-api/src/handlers.ts
+++ b/packages/guardian-api/src/handlers.ts
@@ -1,10 +1,13 @@
+import { Server } from "@arkecosystem/core-api";
+import Boom from "@hapi/boom";
 import Hapi from "@hapi/hapi";
+import { Errors } from "@protokol/guardian-transactions";
 
 import * as Configurations from "./routes/configurations";
 import * as Groups from "./routes/groups";
 import * as Users from "./routes/users";
 
-export = {
+export const Handler = {
     async register(server: Hapi.Server): Promise<void> {
         Configurations.register(server);
         Users.register(server);
@@ -12,4 +15,22 @@ export = {
     },
     name: "Guardian Api",
     version: "1.0.0",
+};
+
+export const initForbiddenErrorHandler = (server: Server): void => {
+    const route = server.getRoute("POST", "/api/transactions");
+    if (!route) return;
+
+    const originalHandler = route.settings.handler.bind(route.settings.bind);
+    route.settings.handler = async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+        try {
+            return await originalHandler(request, h);
+        } catch (err) {
+            if (err instanceof Errors.WalletDoesntHavePermissionsError) {
+                return Boom.forbidden(`Sending of ${err.type}/${err.group!} not allowed for this sender`);
+            }
+
+            throw err;
+        }
+    };
 };

--- a/packages/guardian-api/src/service-provider.ts
+++ b/packages/guardian-api/src/service-provider.ts
@@ -1,7 +1,7 @@
 import { Identifiers as ApiIdentifiers, Server } from "@arkecosystem/core-api";
 import { Providers } from "@arkecosystem/core-kernel";
 
-import Handlers from "./handlers";
+import { Handler, initForbiddenErrorHandler } from "./handlers";
 import { Identifiers } from "./identifiers";
 import { GroupSearchService, UserSearchService } from "./services";
 
@@ -12,10 +12,12 @@ export class ServiceProvider extends Providers.ServiceProvider {
 
         for (const identifier of [ApiIdentifiers.HTTP, ApiIdentifiers.HTTPS]) {
             if (this.app.isBound<Server>(identifier)) {
-                await this.app.get<Server>(identifier).register({
-                    plugin: Handlers,
+                const server = this.app.get<Server>(identifier);
+                await server.register({
+                    plugin: Handler,
                     routes: { prefix: "/api/guardian" },
                 });
+                initForbiddenErrorHandler(server);
             }
         }
     }

--- a/packages/guardian-transactions/src/errors.ts
+++ b/packages/guardian-transactions/src/errors.ts
@@ -28,7 +28,7 @@ export class GroupDoesntExistError extends Errors.TransactionError {
 
 // PermissionResolver errors
 export class WalletDoesntHavePermissionsError extends Errors.TransactionError {
-    public constructor() {
+    public constructor(public readonly type: number, public readonly group: number | undefined) {
         super(`Failed to verify transaction, because wallet doesn't have enough permissions.`);
     }
 }

--- a/packages/guardian-transactions/src/errors.ts
+++ b/packages/guardian-transactions/src/errors.ts
@@ -29,7 +29,7 @@ export class GroupDoesntExistError extends Errors.TransactionError {
 // PermissionResolver errors
 export class WalletDoesntHavePermissionsError extends Errors.TransactionError {
     public constructor(public readonly type: number, public readonly group: number | undefined) {
-        super(`Failed to verify transaction, because wallet doesn't have enough permissions.`);
+        super(`Failed to accept transaction, because wallet doesn't have enough permissions.`);
     }
 }
 

--- a/packages/guardian-transactions/src/index.ts
+++ b/packages/guardian-transactions/src/index.ts
@@ -1,7 +1,8 @@
 import * as Defaults from "./defaults";
+import * as Errors from "./errors";
 import * as Handlers from "./handlers";
 import * as Interfaces from "./interfaces";
 import * as Indexers from "./wallet-indexes";
 export * from "./service-provider";
 
-export { Handlers, Defaults, Interfaces, Indexers };
+export { Handlers, Defaults, Interfaces, Indexers, Errors };

--- a/packages/guardian-transactions/src/service-provider.ts
+++ b/packages/guardian-transactions/src/service-provider.ts
@@ -45,7 +45,7 @@ export class ServiceProvider extends Providers.ServiceProvider {
                 if (
                     !(await this.app.get<PermissionResolver>(Identifiers.PermissionsResolver).resolve(data.transaction))
                 ) {
-                    throw new WalletDoesntHavePermissionsError();
+                    throw new WalletDoesntHavePermissionsError(data.transaction.type, data.transaction.typeGroup);
                 }
             });
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

### What changes are being made?
Added custom error handler which returns 403 with a message instead of generic 500 error when the sender tries to post a transaction without enough permissions.

CU-90tvh4

### Why are these changes necessary?
To give the user a better error description when tries to submit a transaction without enough permissions. These errors could be consumed in frontend and gives the user more information about what went wrong.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->

